### PR TITLE
Add missing dep on reason for js_of_ocaml-compiler

### DIFF
--- a/js_of_ocaml-compiler.opam
+++ b/js_of_ocaml-compiler.opam
@@ -14,6 +14,7 @@ depends: [
   "ocaml" {>= "4.02.0"}
   "dune" {build & >= "1.2"}
   "cmdliner"
+  "reason"
   "cppo" {>= "1.1.0"}
   "yojson" # It's optional, but we want users to be able to use source-map without pain.
 ]


### PR DESCRIPTION
This makes it buildable.