### PR TITLE
Track continue scope

### DIFF
--- a/compiler/lib/RehpDriver.re
+++ b/compiler/lib/RehpDriver.re
@@ -610,7 +610,7 @@ let output_php =
     switch (linkinfos) {
     | None => (
         [],
-        Php_from_rehp.{vars: initialEnv, label: Php_from_rehp.NoLabel},
+        Php_from_rehp.{vars: initialEnv, enclosed_by: Php_from_rehp.NoLoopOrSwitch},
       )
     | Some(linkinfos) =>
       let envWithRuntimeVars =
@@ -622,7 +622,7 @@ let output_php =
       let {Linker.runtime_code, always_required_codes} =
         Linker.link(linkinfos);
       let initialEnv =
-        Php_from_rehp.{vars: initialEnv, label: Php_from_rehp.NoLabel};
+        Php_from_rehp.{vars: initialEnv, enclosed_by: Php_from_rehp.NoLoopOrSwitch};
       let (_, mapped) =
         [
           runtime_code,
@@ -638,7 +638,7 @@ let output_php =
         mapped,
         Php_from_rehp.{
           vars: envWithRuntimeVars,
-          label: Php_from_rehp.NoLabel,
+          enclosed_by: Php_from_rehp.NoLoopOrSwitch,
         },
       );
     };

--- a/compiler/lib/RehpDriver.re
+++ b/compiler/lib/RehpDriver.re
@@ -608,7 +608,10 @@ let output_php =
     );
   let (runtimePhp, env) =
     switch (linkinfos) {
-    | None => ([], initialEnv)
+    | None => (
+        [],
+        Php_from_rehp.{vars: initialEnv, label: Php_from_rehp.NoLabel},
+      )
     | Some(linkinfos) =>
       let envWithRuntimeVars =
         List.fold_left(
@@ -618,6 +621,8 @@ let output_php =
         );
       let {Linker.runtime_code, always_required_codes} =
         Linker.link(linkinfos);
+      let initialEnv =
+        Php_from_rehp.{vars: initialEnv, label: Php_from_rehp.NoLabel};
       let (_, mapped) =
         [
           runtime_code,
@@ -629,7 +634,13 @@ let output_php =
         /* Render the stubs with an env that includes themselves because we
          * know they'll be placed in the correct topological sort (mostly). */
         |> Php_from_rehp.(program(initialEnv));
-      (mapped, envWithRuntimeVars);
+      (
+        mapped,
+        Php_from_rehp.{
+          vars: envWithRuntimeVars,
+          label: Php_from_rehp.NoLabel,
+        },
+      );
     };
 
   let (_, php) = Php_from_rehp.(program(env, rehp));

--- a/compiler/lib/php_from_rehp.re
+++ b/compiler/lib/php_from_rehp.re
@@ -1042,8 +1042,9 @@ and statement = (curOut, input: input, x) => {
       let output = outAppend(outAppend(exprOutput, ifOutput), soptOut);
       (output, If_statement(exprMapped, ifMapped, soptMapped, false));
     | Rehp.Do_while_statement((s, loc), e) =>
-      let (sOut, sMapped) = statement(curOut, input, s);
-      let (eOut, eMapped) = expression(input, e);
+      let nextInput = {...input, enclosed_by: UnlabelledLoop};
+      let (sOut, sMapped) = statement(curOut, nextInput, s);
+      let (eOut, eMapped) = expression(nextInput, e);
       let out = outAppend(sOut, eOut);
       let out = {
         ...out,
@@ -1051,8 +1052,9 @@ and statement = (curOut, input: input, x) => {
       };
       (out, Do_while_statement((sMapped, loc), eMapped));
     | Rehp.While_statement(e, (s, loc)) =>
-      let (sOut, sMapped) = statement(curOut, input, s);
-      let (eOut, eMapped) = expression(input, e);
+      let nextInput = {...input, enclosed_by: UnlabelledLoop};
+      let (sOut, sMapped) = statement(curOut, nextInput, s);
+      let (eOut, eMapped) = expression(nextInput, e);
       let out = outAppend(sOut, eOut);
       let out = {
         ...out,
@@ -1073,8 +1075,9 @@ and statement = (curOut, input: input, x) => {
             let (initOut, initMapped) = optOutput(initialiser(input), e);
             (initOut, Right((Php.EVar(identMapped), initMapped)));
           };
-        let (e2Out, e2Mapped) = expression(input, e2);
-        let (sOut, sMapped) = statement(curOut, input, s);
+        let nextInput = {...input, enclosed_by: UnlabelledLoop};
+        let (e2Out, e2Mapped) = expression(nextInput, e2);
+        let (sOut, sMapped) = statement(curOut, nextInput, s);
         let outs = outAppend(outAppend(e1Out, e2Out), sOut);
         let outs = {
           ...outs,
@@ -1087,8 +1090,8 @@ and statement = (curOut, input: input, x) => {
       | Right((id, _eopt)) =>
         let addedVars = useOneVar(id);
         let augmentedInput = {
+          ...input,
           vars: append(input.vars, addedVars),
-          enclosed_by: input.enclosed_by,
         };
         let (out, res) = continueWithAugmentedScope(augmentedInput, x);
         let out = {...out, dec: append(out.dec, addedVars)};

--- a/compiler/lib/php_from_rehp.re
+++ b/compiler/lib/php_from_rehp.re
@@ -757,32 +757,6 @@ and unop_from_rehp = (input, unop, rehpExpr) =>
     (outMapped, EUn(DecrB, exprMapped));
   }
 and switchCase = (input, e) => expression(input, e)
-and ifElseFromSwitchCase = (switchExp, defaultBlock) => {
-  let elseStmts =
-    switch (defaultBlock) {
-    | None => None
-    | Some(defaultBlock) => Some(Php.Statement_list(defaultBlock))
-    };
-  let rec f = cases =>
-    switch (cases) {
-    | [] => elseStmts
-    | [(caseExp, caseBlock), ...remainingCases] =>
-      let alternate =
-        switch (f(remainingCases)) {
-        | None => None
-        | Some(e) => Some((e, Loc.N))
-        };
-      Some(
-        Php.If_statement(
-          Php.EBin(Php.EqEqEq, switchExp, caseExp),
-          (Statement_list(caseBlock), Loc.N),
-          alternate,
-          true,
-        ),
-      );
-    };
-  f;
-}
 and initialiser = (input: input, (e, pc)) => {
   let (o, m) = expression(input, e);
   (o, (m, pc));

--- a/compiler/lib/php_from_rehp.rei
+++ b/compiler/lib/php_from_rehp.rei
@@ -20,7 +20,15 @@ type output = {
   use_continue: bool,
 };
 
-type input = vars;
+type parent_label =
+  | NoLabel
+  | UnlabelledForLoop
+  | LabelledForLoop(string)
+  | Switch;
+type input = {
+  vars,
+  label: parent_label,
+};
 let addOne: (vars, Id.t) => vars;
 let empty: vars;
 let expression: (input, Rehp.expression) => (output, Php.expression);
@@ -28,9 +36,12 @@ let switchCase: (input, Rehp.expression) => (output, Php.expression);
 let initialiser:
   (input, (Rehp.expression, Loc.t)) => (output, (Php.expression, Loc.t));
 let statement: (output, input, Rehp.statement) => (output, Php.statement);
-let statements: (output, input, Rehp.statement_list) => (output, Php.statement_list);
-let source: (output, input, Rehp.source_element) => (output, Php.source_element);
-let sources: (output, input, Rehp.source_elements) => (output, Php.source_elements);
+let statements:
+  (output, input, Rehp.statement_list) => (output, Php.statement_list);
+let source:
+  (output, input, Rehp.source_element) => (output, Php.source_element);
+let sources:
+  (output, input, Rehp.source_elements) => (output, Php.source_elements);
 let ident: (~ref: bool=?, input, Id.t) => Id.t;
 let program: (input, Rehp.program) => (output, Php.program);
 let binop_from_rehp: Rehp.binop => Php.binop;

--- a/compiler/lib/php_from_rehp.rei
+++ b/compiler/lib/php_from_rehp.rei
@@ -18,6 +18,7 @@ type output = {
   use: vars,
   use_label: bool,
   use_continue: bool,
+  unshielded_continues: list(string),
 };
 
 type parent_label =

--- a/compiler/lib/php_from_rehp.rei
+++ b/compiler/lib/php_from_rehp.rei
@@ -16,8 +16,6 @@ type output = {
    * be bound by a higher containing term).
    */
   use: vars,
-  use_label: bool,
-  use_continue: bool,
   unshielded_continues: list(string),
 };
 

--- a/compiler/lib/php_from_rehp.rei
+++ b/compiler/lib/php_from_rehp.rei
@@ -16,17 +16,17 @@ type output = {
    * be bound by a higher containing term).
    */
   use: vars,
-  unshielded_continues: list(string),
+  free_labels: list(string),
 };
 
-type parent_label =
-  | NoLabel
-  | UnlabelledForLoop
+type enclosed_by =
+  | NoLoopOrSwitch
+  | UnlabelledLoop
   | LabelledForLoop(string)
   | Switch;
 type input = {
   vars,
-  label: parent_label,
+  enclosed_by,
 };
 let addOne: (vars, Id.t) => vars;
 let empty: vars;

--- a/rehack_tests/js/js_of_ocaml.cma.js/Js_of_ocaml__Lib_version.js
+++ b/rehack_tests/js/js_of_ocaml.cma.js/Js_of_ocaml__Lib_version.js
@@ -12,7 +12,7 @@ let joo_global_object = global;
 var runtime = joo_global_object.jsoo_runtime;
 var string = runtime["caml_new_string"];
 var s = string("3.3.0");
-var git_version = string("c9cd029b");
+var git_version = string("f5a8306e");
 var Js_of_ocaml_Lib_version = [0,s,git_version];
 
 runtime["caml_register_global"](

--- a/rehack_tests/js/js_of_ocaml.cma.js/Js_of_ocaml__Lib_version.js
+++ b/rehack_tests/js/js_of_ocaml.cma.js/Js_of_ocaml__Lib_version.js
@@ -12,7 +12,7 @@ let joo_global_object = global;
 var runtime = joo_global_object.jsoo_runtime;
 var string = runtime["caml_new_string"];
 var s = string("3.3.0");
-var git_version = string("5fe32e4d");
+var git_version = string("c9cd029b");
 var Js_of_ocaml_Lib_version = [0,s,git_version];
 
 runtime["caml_register_global"](

--- a/rehack_tests/js/js_of_ocaml.cma.js/Js_of_ocaml__Lib_version.js
+++ b/rehack_tests/js/js_of_ocaml.cma.js/Js_of_ocaml__Lib_version.js
@@ -12,7 +12,7 @@ let joo_global_object = global;
 var runtime = joo_global_object.jsoo_runtime;
 var string = runtime["caml_new_string"];
 var s = string("3.3.0");
-var git_version = string("0d660c71");
+var git_version = string("35378b53");
 var Js_of_ocaml_Lib_version = [0,s,git_version];
 
 runtime["caml_register_global"](

--- a/rehack_tests/js/js_of_ocaml.cma.js/Js_of_ocaml__Lib_version.js
+++ b/rehack_tests/js/js_of_ocaml.cma.js/Js_of_ocaml__Lib_version.js
@@ -12,7 +12,7 @@ let joo_global_object = global;
 var runtime = joo_global_object.jsoo_runtime;
 var string = runtime["caml_new_string"];
 var s = string("3.3.0");
-var git_version = string("36666bff");
+var git_version = string("0d660c71");
 var Js_of_ocaml_Lib_version = [0,s,git_version];
 
 runtime["caml_register_global"](

--- a/rehack_tests/js/js_of_ocaml.cma.js/Js_of_ocaml__Lib_version.js
+++ b/rehack_tests/js/js_of_ocaml.cma.js/Js_of_ocaml__Lib_version.js
@@ -12,7 +12,7 @@ let joo_global_object = global;
 var runtime = joo_global_object.jsoo_runtime;
 var string = runtime["caml_new_string"];
 var s = string("3.3.0");
-var git_version = string("82616ea3");
+var git_version = string("5fe32e4d");
 var Js_of_ocaml_Lib_version = [0,s,git_version];
 
 runtime["caml_register_global"](

--- a/rehack_tests/js/js_of_ocaml.cma.js/Js_of_ocaml__Lib_version.js
+++ b/rehack_tests/js/js_of_ocaml.cma.js/Js_of_ocaml__Lib_version.js
@@ -12,7 +12,7 @@ let joo_global_object = global;
 var runtime = joo_global_object.jsoo_runtime;
 var string = runtime["caml_new_string"];
 var s = string("3.3.0");
-var git_version = string("f5a8306e");
+var git_version = string("36666bff");
 var Js_of_ocaml_Lib_version = [0,s,git_version];
 
 runtime["caml_register_global"](

--- a/rehack_tests/js/js_of_ocaml.cma.php/Js_of_ocaml__Lib_version.php
+++ b/rehack_tests/js/js_of_ocaml.cma.php/Js_of_ocaml__Lib_version.php
@@ -31,7 +31,7 @@ final class Js_of_ocaml__Lib_version {
     $runtime = $joo_global_object->jsoo_runtime;
     $string = $runtime["caml_new_string"];
     $s = $string("3.3.0");
-    $git_version = $string("36666bff");
+    $git_version = $string("0d660c71");
     $Js_of_ocaml_Lib_version = Vector{0, $s, $git_version};
     
     $runtime["caml_register_global"](

--- a/rehack_tests/js/js_of_ocaml.cma.php/Js_of_ocaml__Lib_version.php
+++ b/rehack_tests/js/js_of_ocaml.cma.php/Js_of_ocaml__Lib_version.php
@@ -31,7 +31,7 @@ final class Js_of_ocaml__Lib_version {
     $runtime = $joo_global_object->jsoo_runtime;
     $string = $runtime["caml_new_string"];
     $s = $string("3.3.0");
-    $git_version = $string("5fe32e4d");
+    $git_version = $string("c9cd029b");
     $Js_of_ocaml_Lib_version = Vector{0, $s, $git_version};
     
     $runtime["caml_register_global"](

--- a/rehack_tests/js/js_of_ocaml.cma.php/Js_of_ocaml__Lib_version.php
+++ b/rehack_tests/js/js_of_ocaml.cma.php/Js_of_ocaml__Lib_version.php
@@ -31,7 +31,7 @@ final class Js_of_ocaml__Lib_version {
     $runtime = $joo_global_object->jsoo_runtime;
     $string = $runtime["caml_new_string"];
     $s = $string("3.3.0");
-    $git_version = $string("f5a8306e");
+    $git_version = $string("36666bff");
     $Js_of_ocaml_Lib_version = Vector{0, $s, $git_version};
     
     $runtime["caml_register_global"](

--- a/rehack_tests/js/js_of_ocaml.cma.php/Js_of_ocaml__Lib_version.php
+++ b/rehack_tests/js/js_of_ocaml.cma.php/Js_of_ocaml__Lib_version.php
@@ -31,7 +31,7 @@ final class Js_of_ocaml__Lib_version {
     $runtime = $joo_global_object->jsoo_runtime;
     $string = $runtime["caml_new_string"];
     $s = $string("3.3.0");
-    $git_version = $string("0d660c71");
+    $git_version = $string("35378b53");
     $Js_of_ocaml_Lib_version = Vector{0, $s, $git_version};
     
     $runtime["caml_register_global"](

--- a/rehack_tests/js/js_of_ocaml.cma.php/Js_of_ocaml__Lib_version.php
+++ b/rehack_tests/js/js_of_ocaml.cma.php/Js_of_ocaml__Lib_version.php
@@ -31,7 +31,7 @@ final class Js_of_ocaml__Lib_version {
     $runtime = $joo_global_object->jsoo_runtime;
     $string = $runtime["caml_new_string"];
     $s = $string("3.3.0");
-    $git_version = $string("c9cd029b");
+    $git_version = $string("f5a8306e");
     $Js_of_ocaml_Lib_version = Vector{0, $s, $git_version};
     
     $runtime["caml_register_global"](

--- a/rehack_tests/js/js_of_ocaml.cma.php/Js_of_ocaml__Lib_version.php
+++ b/rehack_tests/js/js_of_ocaml.cma.php/Js_of_ocaml__Lib_version.php
@@ -31,7 +31,7 @@ final class Js_of_ocaml__Lib_version {
     $runtime = $joo_global_object->jsoo_runtime;
     $string = $runtime["caml_new_string"];
     $s = $string("3.3.0");
-    $git_version = $string("82616ea3");
+    $git_version = $string("5fe32e4d");
     $Js_of_ocaml_Lib_version = Vector{0, $s, $git_version};
     
     $runtime["caml_register_global"](

--- a/rehack_tests/loop_labels/loop_labels.php
+++ b/rehack_tests/loop_labels/loop_labels.php
@@ -897,9 +897,6 @@ $h3 = function(dynamic $g, dynamic $t) use ($caml_call1) {
       default:
         $caml_call1($g, 1);
     }
-    if ($continue_label !== null) {
-      break;
-    }
     $G = (int)($i + 1);
     if (5 !== $i) {
       $i = $G;
@@ -984,9 +981,6 @@ $h5 = function(dynamic $g, dynamic $t) use ($caml_call1) {
           // FALLTHROUGH
         default:
           $caml_call1($g, 1);
-      }
-      if ($continue_label !== null) {
-        break;
       }
       $B = (int)($j + 1);
       if (3 !== $j) {

--- a/rehack_tests/loop_labels/loop_labels.php
+++ b/rehack_tests/loop_labels/loop_labels.php
@@ -436,9 +436,6 @@ $f4 = function(dynamic $g) use ($caml_call1) {
                           }
                           return 0;
                         }
-                        if ($continue_label !== null) {
-                          break;
-                        }
                       }
                       if ($continue_label !== null) {
                         break;

--- a/rehack_tests/loop_labels/loop_labels.php
+++ b/rehack_tests/loop_labels/loop_labels.php
@@ -253,7 +253,7 @@ $f1 = function(dynamic $g) use ($caml_call1) {
 };
 $f2 = function(dynamic $g) use ($caml_call1) {
   $i = 2;
-  $continue_counter = null;
+  $continue_label = null;
   for (; ; ) {
     $j = 4;
     for (; ; ) {
@@ -266,25 +266,24 @@ $f2 = function(dynamic $g) use ($caml_call1) {
       $aJ = (int)($i + 1);
       if (3 !== $i) {
         $i = $aJ;
-        $continue_counter = 0;
+        $continue_label = "a";
         break;
       }
       return 0;
     }
-    if ($continue_counter > 0) {
-      $continue_counter -= 1;
-      break;
-    } else if ($continue_counter === 0) {
-      $continue_counter = null;
+    if ($continue_label === "a") {
       continue;
+    } else if ($continue_label !== null) {
+      break;
     }
   }
 };
 $f3 = function(dynamic $g) use ($caml_call1) {
   $i = 2;
-  $continue_counter = null;
+  $continue_label = null;
   for (; ; ) {
     $j = 4;
+    $continue_label = null;
     for (; ; ) {
       $k = 4;
       for (; ; ) {
@@ -297,7 +296,7 @@ $f3 = function(dynamic $g) use ($caml_call1) {
         $aH = (int)($j + 1);
         if (5 !== $j) {
           $j = $aH;
-          $continue_counter = 0;
+          $continue_label = "b";
           break;
         }
         $l = 6;
@@ -311,39 +310,31 @@ $f3 = function(dynamic $g) use ($caml_call1) {
           $aF = (int)($i + 1);
           if (3 !== $i) {
             $i = $aF;
-            $continue_counter = 2;
+            $continue_label = "a";
             break;
           }
           return 0;
         }
-        if ($continue_counter > 0) {
-          $continue_counter -= 1;
+        if ($continue_label !== null) {
           break;
-        } else if ($continue_counter === 0) {
-          $continue_counter = null;
-          continue;
         }
       }
-      if ($continue_counter > 0) {
-        $continue_counter -= 1;
-        break;
-      } else if ($continue_counter === 0) {
-        $continue_counter = null;
+      if ($continue_label === "b") {
         continue;
+      } else if ($continue_label !== null) {
+        break;
       }
     }
-    if ($continue_counter > 0) {
-      $continue_counter -= 1;
-      break;
-    } else if ($continue_counter === 0) {
-      $continue_counter = null;
+    if ($continue_label === "a") {
       continue;
+    } else if ($continue_label !== null) {
+      break;
     }
   }
 };
 $f4 = function(dynamic $g) use ($caml_call1) {
   $i = 2;
-  $continue_counter = null;
+  $continue_label = null;
   for (; ; ) {
     $k__3 = 4;
     for (; ; ) {
@@ -354,8 +345,10 @@ $f4 = function(dynamic $g) use ($caml_call1) {
         continue;
       }
       $j = 4;
+      $continue_label = null;
       for (; ; ) {
         $k__2 = 4;
+        $continue_label = null;
         for (; ; ) {
           $l__0 = 4;
           for (; ; ) {
@@ -368,7 +361,7 @@ $f4 = function(dynamic $g) use ($caml_call1) {
             $aC = (int)($k__2 + 1);
             if (5 !== $k__2) {
               $k__2 = $aC;
-              $continue_counter = 0;
+              $continue_label = "d";
               break;
             }
             $k__1 = 4;
@@ -382,10 +375,11 @@ $f4 = function(dynamic $g) use ($caml_call1) {
               $aA = (int)($j + 1);
               if (5 !== $j) {
                 $j = $aA;
-                $continue_counter = 2;
+                $continue_label = "c";
                 break;
               }
               $l = 6;
+              $continue_label = null;
               for (; ; ) {
                 $n__0 = 4;
                 for (; ; ) {
@@ -396,6 +390,7 @@ $f4 = function(dynamic $g) use ($caml_call1) {
                     continue;
                   }
                   $m = 4;
+                  $continue_label = null;
                   for (; ; ) {
                     $n = 4;
                     for (; ; ) {
@@ -408,13 +403,13 @@ $f4 = function(dynamic $g) use ($caml_call1) {
                       $ax = (int)($m + 1);
                       if (5 !== $m) {
                         $m = $ax;
-                        $continue_counter = 0;
+                        $continue_label = "f";
                         break;
                       }
                       $aw = (int)($l + 1);
                       if (7 !== $l) {
                         $l = $aw;
-                        $continue_counter = 2;
+                        $continue_label = "e";
                         break;
                       }
                       $k__0 = 4;
@@ -428,7 +423,7 @@ $f4 = function(dynamic $g) use ($caml_call1) {
                         $au = (int)($i + 1);
                         if (3 !== $i) {
                           $i = $au;
-                          $continue_counter = 9;
+                          $continue_label = "a";
                           break;
                         }
                         $k = 4;
@@ -441,92 +436,58 @@ $f4 = function(dynamic $g) use ($caml_call1) {
                           }
                           return 0;
                         }
-                        if ($continue_counter > 0) {
-                          $continue_counter -= 1;
+                        if ($continue_label !== null) {
                           break;
-                        } else if ($continue_counter === 0) {
-                          $continue_counter = null;
-                          continue;
                         }
                       }
-                      if ($continue_counter > 0) {
-                        $continue_counter -= 1;
+                      if ($continue_label !== null) {
                         break;
-                      } else if ($continue_counter === 0) {
-                        $continue_counter = null;
-                        continue;
                       }
                     }
-                    if ($continue_counter > 0) {
-                      $continue_counter -= 1;
-                      break;
-                    } else if ($continue_counter === 0) {
-                      $continue_counter = null;
+                    if ($continue_label === "f") {
                       continue;
+                    } else if ($continue_label !== null) {
+                      break;
                     }
                   }
-                  if ($continue_counter > 0) {
-                    $continue_counter -= 1;
+                  if ($continue_label !== null) {
                     break;
-                  } else if ($continue_counter === 0) {
-                    $continue_counter = null;
-                    continue;
                   }
                 }
-                if ($continue_counter > 0) {
-                  $continue_counter -= 1;
-                  break;
-                } else if ($continue_counter === 0) {
-                  $continue_counter = null;
+                if ($continue_label === "e") {
                   continue;
+                } else if ($continue_label !== null) {
+                  break;
                 }
               }
-              if ($continue_counter > 0) {
-                $continue_counter -= 1;
+              if ($continue_label !== null) {
                 break;
-              } else if ($continue_counter === 0) {
-                $continue_counter = null;
-                continue;
               }
             }
-            if ($continue_counter > 0) {
-              $continue_counter -= 1;
+            if ($continue_label !== null) {
               break;
-            } else if ($continue_counter === 0) {
-              $continue_counter = null;
-              continue;
             }
           }
-          if ($continue_counter > 0) {
-            $continue_counter -= 1;
-            break;
-          } else if ($continue_counter === 0) {
-            $continue_counter = null;
+          if ($continue_label === "d") {
             continue;
+          } else if ($continue_label !== null) {
+            break;
           }
         }
-        if ($continue_counter > 0) {
-          $continue_counter -= 1;
-          break;
-        } else if ($continue_counter === 0) {
-          $continue_counter = null;
+        if ($continue_label === "c") {
           continue;
+        } else if ($continue_label !== null) {
+          break;
         }
       }
-      if ($continue_counter > 0) {
-        $continue_counter -= 1;
+      if ($continue_label !== null) {
         break;
-      } else if ($continue_counter === 0) {
-        $continue_counter = null;
-        continue;
       }
     }
-    if ($continue_counter > 0) {
-      $continue_counter -= 1;
-      break;
-    } else if ($continue_counter === 0) {
-      $continue_counter = null;
+    if ($continue_label === "a") {
       continue;
+    } else if ($continue_label !== null) {
+      break;
     }
   }
 };
@@ -622,7 +583,7 @@ $f8 = function(dynamic $g) use ($caml_call1) {
     }
     $f = function(dynamic $x) use ($caml_call1, $g) {
       $i = 2;
-      $continue_counter = null;
+      $continue_label = null;
       for (; ; ) {
         $j = 4;
         for (; ; ) {
@@ -635,17 +596,15 @@ $f8 = function(dynamic $g) use ($caml_call1) {
           $aj = (int)($i + 1);
           if (3 !== $i) {
             $i = $aj;
-            $continue_counter = 0;
+            $continue_label = "a";
             break;
           }
           return 0;
         }
-        if ($continue_counter > 0) {
-          $continue_counter -= 1;
-          break;
-        } else if ($continue_counter === 0) {
-          $continue_counter = null;
+        if ($continue_label === "a") {
           continue;
+        } else if ($continue_label !== null) {
+          break;
         }
       }
     };
@@ -663,14 +622,14 @@ $f8 = function(dynamic $g) use ($caml_call1) {
 };
 $f9 = function(dynamic $g) use ($caml_call1) {
   $i1 = 2;
-  $continue_counter = null;
+  $continue_label = null;
   for (; ; ) {
     $i2 = 2;
     for (; ; ) {
       $f__0 = function(dynamic $i1, dynamic $i2) use ($caml_call1, $g) {
         $f = function(dynamic $x) use ($caml_call1, $g, $i1, $i2) {
           $i3 = 2;
-          $continue_counter = null;
+          $continue_label = null;
           for (; ; ) {
             $i4 = 2;
             for (; ; ) {
@@ -686,17 +645,15 @@ $f9 = function(dynamic $g) use ($caml_call1) {
               $af = (int)($i3 + 1);
               if (3 !== $i3) {
                 $i3 = $af;
-                $continue_counter = 0;
+                $continue_label = "a";
                 break;
               }
               return 0;
             }
-            if ($continue_counter > 0) {
-              $continue_counter -= 1;
-              break;
-            } else if ($continue_counter === 0) {
-              $continue_counter = null;
+            if ($continue_label === "a") {
               continue;
+            } else if ($continue_label !== null) {
+              break;
             }
           }
         };
@@ -712,17 +669,15 @@ $f9 = function(dynamic $g) use ($caml_call1) {
       $ad = (int)($i1 + 1);
       if (3 !== $i1) {
         $i1 = $ad;
-        $continue_counter = 0;
+        $continue_label = "a";
         break;
       }
       return 0;
     }
-    if ($continue_counter > 0) {
-      $continue_counter -= 1;
-      break;
-    } else if ($continue_counter === 0) {
-      $continue_counter = null;
+    if ($continue_label === "a") {
       continue;
+    } else if ($continue_label !== null) {
+      break;
     }
   }
 };
@@ -734,12 +689,13 @@ $f10 = function(dynamic $g) use (
   $caml_wrap_thrown_exception_reraise,
 ) {
   $i1 = 2;
-  $continue_counter = null;
+  $continue_label = null;
   for (; ; ) {
     $i2 = 2;
     for (; ; ) {
       try {
         $i3 = 2;
+        $continue_label = null;
         for (; ; ) {
           $i4 = 2;
           for (; ; ) {
@@ -755,26 +711,20 @@ $f10 = function(dynamic $g) use (
             $aa = (int)($i3 + 1);
             if (3 !== $i3) {
               $i3 = $aa;
-              $continue_counter = 0;
+              $continue_label = "c";
               break;
             }
             break;
           }
-          if ($continue_counter > 0) {
-            $continue_counter -= 1;
-            break;
-          } else if ($continue_counter === 0) {
-            $continue_counter = null;
+          if ($continue_label === "c") {
             continue;
+          } else if ($continue_label !== null) {
+            break;
           }
           break;
         }
-        if ($continue_counter > 0) {
-          $continue_counter -= 1;
+        if ($continue_label !== null) {
           break;
-        } else if ($continue_counter === 0) {
-          $continue_counter = null;
-          continue;
         }
       } catch (\Throwable $ac) {
         $ac = $caml_wrap_exception($ac);
@@ -790,17 +740,15 @@ $f10 = function(dynamic $g) use (
       $Y = (int)($i1 + 1);
       if (3 !== $i1) {
         $i1 = $Y;
-        $continue_counter = 0;
+        $continue_label = "a";
         break;
       }
       return 0;
     }
-    if ($continue_counter > 0) {
-      $continue_counter -= 1;
-      break;
-    } else if ($continue_counter === 0) {
-      $continue_counter = null;
+    if ($continue_label === "a") {
       continue;
+    } else if ($continue_label !== null) {
+      break;
     }
   }
 };
@@ -888,7 +836,7 @@ $h1 = function(dynamic $g, dynamic $t) use ($caml_call1) {
 };
 $h2 = function(dynamic $g, dynamic $t) use ($caml_call1) {
   $i = 2;
-  $continue_counter = null;
+  $continue_label = null;
   for (; ; ) {
     $j = 2;
     for (; ; ) {
@@ -922,64 +870,67 @@ $h2 = function(dynamic $g, dynamic $t) use ($caml_call1) {
       $J = (int)($i + 1);
       if (3 !== $i) {
         $i = $J;
-        $continue_counter = 0;
+        $continue_label = "a";
         break;
       }
       return 0;
     }
-    if ($continue_counter > 0) {
-      $continue_counter -= 1;
-      break;
-    } else if ($continue_counter === 0) {
-      $continue_counter = null;
+    if ($continue_label === "a") {
       continue;
+    } else if ($continue_label !== null) {
+      break;
     }
   }
 };
 $h3 = function(dynamic $g, dynamic $t) use ($caml_call1) {
   $i = 4;
   for (; ; ) {
-    if ($t === 0) {
-      $caml_call1($g, 0);
-      break;
-    } else if ($t === 1) {
-      $j = 4;
-      for (; ; ) {
-        $k = 2;
+    $continue_label = null;
+    switch ($t) {
+        // FALLTHROUGH
+      case 0:
+        $caml_call1($g, 0);
+        break;
+        // FALLTHROUGH
+      case 1:
+        $j = 4;
+        $continue_label = null;
         for (; ; ) {
-          $caml_call1($g, (int)((int)($i + $j) + $k));
-          $I = (int)($k + 1);
-          if (3 !== $k) {
-            $k = $I;
-            continue;
+          $k = 2;
+          for (; ; ) {
+            $caml_call1($g, (int)((int)($i + $j) + $k));
+            $I = (int)($k + 1);
+            if (3 !== $k) {
+              $k = $I;
+              continue;
+            }
+            $H = (int)($j + 1);
+            if (5 !== $j) {
+              $j = $H;
+              $continue_label = "b";
+              break;
+            }
+            break;
           }
-          $H = (int)($j + 1);
-          if (5 !== $j) {
-            $j = $H;
-            $continue_counter = 0;
+          if ($continue_label === "b") {
+            continue;
+          } else if ($continue_label !== null) {
             break;
           }
           break;
         }
-        if ($continue_counter > 0) {
-          $continue_counter -= 1;
+        if ($continue_label !== null) {
           break;
-        } else if ($continue_counter === 0) {
-          $continue_counter = null;
-          continue;
         }
         break;
-      }
-      if ($continue_counter > 0) {
-        $continue_counter -= 1;
-        break;
-      } else if ($continue_counter === 0) {
-        $continue_counter = null;
-        continue;
-      }
+        // FALLTHROUGH
+      default:
+        $caml_call1($g, 1);
+    }
+    if ($continue_label === "switch") {
+      continue;
+    } else if ($continue_label !== null) {
       break;
-    } else {
-      $caml_call1($g, 1);
     }
     $G = (int)($i + 1);
     if (5 !== $i) {
@@ -997,7 +948,7 @@ $h4 = function(dynamic $g, dynamic $t) use ($caml_call1) {
       // FALLTHROUGH
     case 1:
       $j = 4;
-      $continue_counter = null;
+      $continue_label = null;
       for (; ; ) {
         $k = 2;
         for (; ; ) {
@@ -1010,18 +961,19 @@ $h4 = function(dynamic $g, dynamic $t) use ($caml_call1) {
           $E = (int)($j + 1);
           if (5 !== $j) {
             $j = $E;
-            $continue_counter = 0;
+            $continue_label = "a";
             break;
           }
           return 0;
         }
-        if ($continue_counter > 0) {
-          $continue_counter -= 1;
-          break;
-        } else if ($continue_counter === 0) {
-          $continue_counter = null;
+        if ($continue_label === "a") {
           continue;
+        } else if ($continue_label !== null) {
+          break;
         }
+      }
+      if ($continue_label !== null) {
+        break;
       }
       // FALLTHROUGH
     default:
@@ -1030,51 +982,56 @@ $h4 = function(dynamic $g, dynamic $t) use ($caml_call1) {
 };
 $h5 = function(dynamic $g, dynamic $t) use ($caml_call1) {
   $i = 2;
-  $continue_counter = null;
+  $continue_label = null;
   for (; ; ) {
     $j = 2;
     for (; ; ) {
-      if ($t === 0) {
-        $caml_call1($g, 0);
-        break;
-      } else if ($t === 1) {
-        $k = 4;
-        for (; ; ) {
-          $l = 2;
+      $continue_label = null;
+      switch ($t) {
+          // FALLTHROUGH
+        case 0:
+          $caml_call1($g, 0);
+          break;
+          // FALLTHROUGH
+        case 1:
+          $k = 4;
+          $continue_label = null;
           for (; ; ) {
-            $caml_call1($g, (int)((int)($i + $j) + $k));
-            $D = (int)($l + 1);
-            if (3 !== $l) {
-              $l = $D;
-              continue;
+            $l = 2;
+            for (; ; ) {
+              $caml_call1($g, (int)((int)($i + $j) + $k));
+              $D = (int)($l + 1);
+              if (3 !== $l) {
+                $l = $D;
+                continue;
+              }
+              $C = (int)($k + 1);
+              if (5 !== $k) {
+                $k = $C;
+                $continue_label = "c";
+                break;
+              }
+              break;
             }
-            $C = (int)($k + 1);
-            if (5 !== $k) {
-              $k = $C;
-              $continue_counter = 0;
+            if ($continue_label === "c") {
+              continue;
+            } else if ($continue_label !== null) {
               break;
             }
             break;
           }
-          if ($continue_counter > 0) {
-            $continue_counter -= 1;
+          if ($continue_label !== null) {
             break;
-          } else if ($continue_counter === 0) {
-            $continue_counter = null;
-            continue;
           }
           break;
-        }
-        if ($continue_counter > 0) {
-          $continue_counter -= 1;
-          break;
-        } else if ($continue_counter === 0) {
-          $continue_counter = null;
-          continue;
-        }
+          // FALLTHROUGH
+        default:
+          $caml_call1($g, 1);
+      }
+      if ($continue_label === "switch") {
+        continue;
+      } else if ($continue_label !== null) {
         break;
-      } else {
-        $caml_call1($g, 1);
       }
       $B = (int)($j + 1);
       if (3 !== $j) {
@@ -1084,17 +1041,15 @@ $h5 = function(dynamic $g, dynamic $t) use ($caml_call1) {
       $A = (int)($i + 1);
       if (3 !== $i) {
         $i = $A;
-        $continue_counter = 0;
+        $continue_label = "a";
         break;
       }
       return 0;
     }
-    if ($continue_counter > 0) {
-      $continue_counter -= 1;
-      break;
-    } else if ($continue_counter === 0) {
-      $continue_counter = null;
+    if ($continue_label === "a") {
       continue;
+    } else if ($continue_label !== null) {
+      break;
     }
   }
 };

--- a/rehack_tests/loop_labels/loop_labels.php
+++ b/rehack_tests/loop_labels/loop_labels.php
@@ -253,8 +253,8 @@ $f1 = function(dynamic $g) use ($caml_call1) {
 };
 $f2 = function(dynamic $g) use ($caml_call1) {
   $i = 2;
-  $continue_label = null;
   for (; ; ) {
+    $continue_label = null;
     $j = 4;
     for (; ; ) {
       $caml_call1($g, (int)($i + $j));
@@ -273,18 +273,16 @@ $f2 = function(dynamic $g) use ($caml_call1) {
     }
     if ($continue_label === "a") {
       continue;
-    } else if ($continue_label !== null) {
-      break;
     }
   }
 };
 $f3 = function(dynamic $g) use ($caml_call1) {
   $i = 2;
-  $continue_label = null;
   for (; ; ) {
-    $j = 4;
     $continue_label = null;
+    $j = 4;
     for (; ; ) {
+      $continue_label = null;
       $k = 4;
       for (; ; ) {
         $caml_call1($g, (int)((int)($i + $j) + $k));
@@ -327,15 +325,13 @@ $f3 = function(dynamic $g) use ($caml_call1) {
     }
     if ($continue_label === "a") {
       continue;
-    } else if ($continue_label !== null) {
-      break;
     }
   }
 };
 $f4 = function(dynamic $g) use ($caml_call1) {
   $i = 2;
-  $continue_label = null;
   for (; ; ) {
+    $continue_label = null;
     $k__3 = 4;
     for (; ; ) {
       $caml_call1($g, (int)($i + $k__3));
@@ -345,11 +341,11 @@ $f4 = function(dynamic $g) use ($caml_call1) {
         continue;
       }
       $j = 4;
-      $continue_label = null;
       for (; ; ) {
-        $k__2 = 4;
         $continue_label = null;
+        $k__2 = 4;
         for (; ; ) {
+          $continue_label = null;
           $l__0 = 4;
           for (; ; ) {
             $caml_call1($g, (int)((int)((int)($i + $j) + $k__2) + $l__0));
@@ -379,8 +375,8 @@ $f4 = function(dynamic $g) use ($caml_call1) {
                 break;
               }
               $l = 6;
-              $continue_label = null;
               for (; ; ) {
+                $continue_label = null;
                 $n__0 = 4;
                 for (; ; ) {
                   $caml_call1($g, (int)((int)($i + $l) + $n__0));
@@ -390,8 +386,8 @@ $f4 = function(dynamic $g) use ($caml_call1) {
                     continue;
                   }
                   $m = 4;
-                  $continue_label = null;
                   for (; ; ) {
+                    $continue_label = null;
                     $n = 4;
                     for (; ; ) {
                       $caml_call1($g, (int)((int)((int)($i + $l) + $m) + $n));
@@ -483,8 +479,6 @@ $f4 = function(dynamic $g) use ($caml_call1) {
     }
     if ($continue_label === "a") {
       continue;
-    } else if ($continue_label !== null) {
-      break;
     }
   }
 };
@@ -580,8 +574,8 @@ $f8 = function(dynamic $g) use ($caml_call1) {
     }
     $f = function(dynamic $x) use ($caml_call1, $g) {
       $i = 2;
-      $continue_label = null;
       for (; ; ) {
+        $continue_label = null;
         $j = 4;
         for (; ; ) {
           $caml_call1($g, (int)((int)($x + $i) + $j));
@@ -600,8 +594,6 @@ $f8 = function(dynamic $g) use ($caml_call1) {
         }
         if ($continue_label === "a") {
           continue;
-        } else if ($continue_label !== null) {
-          break;
         }
       }
     };
@@ -619,15 +611,15 @@ $f8 = function(dynamic $g) use ($caml_call1) {
 };
 $f9 = function(dynamic $g) use ($caml_call1) {
   $i1 = 2;
-  $continue_label = null;
   for (; ; ) {
+    $continue_label = null;
     $i2 = 2;
     for (; ; ) {
       $f__0 = function(dynamic $i1, dynamic $i2) use ($caml_call1, $g) {
         $f = function(dynamic $x) use ($caml_call1, $g, $i1, $i2) {
           $i3 = 2;
-          $continue_label = null;
           for (; ; ) {
+            $continue_label = null;
             $i4 = 2;
             for (; ; ) {
               $caml_call1(
@@ -649,8 +641,6 @@ $f9 = function(dynamic $g) use ($caml_call1) {
             }
             if ($continue_label === "a") {
               continue;
-            } else if ($continue_label !== null) {
-              break;
             }
           }
         };
@@ -673,8 +663,6 @@ $f9 = function(dynamic $g) use ($caml_call1) {
     }
     if ($continue_label === "a") {
       continue;
-    } else if ($continue_label !== null) {
-      break;
     }
   }
 };
@@ -686,14 +674,14 @@ $f10 = function(dynamic $g) use (
   $caml_wrap_thrown_exception_reraise,
 ) {
   $i1 = 2;
-  $continue_label = null;
   for (; ; ) {
+    $continue_label = null;
     $i2 = 2;
     for (; ; ) {
       try {
         $i3 = 2;
-        $continue_label = null;
         for (; ; ) {
+          $continue_label = null;
           $i4 = 2;
           for (; ; ) {
             $caml_call1($g, (int)((int)((int)($i1 + $i2) + $i3) + $i4));
@@ -715,12 +703,7 @@ $f10 = function(dynamic $g) use (
           }
           if ($continue_label === "c") {
             continue;
-          } else if ($continue_label !== null) {
-            break;
           }
-          break;
-        }
-        if ($continue_label !== null) {
           break;
         }
       } catch (\Throwable $ac) {
@@ -744,8 +727,6 @@ $f10 = function(dynamic $g) use (
     }
     if ($continue_label === "a") {
       continue;
-    } else if ($continue_label !== null) {
-      break;
     }
   }
 };
@@ -833,8 +814,8 @@ $h1 = function(dynamic $g, dynamic $t) use ($caml_call1) {
 };
 $h2 = function(dynamic $g, dynamic $t) use ($caml_call1) {
   $i = 2;
-  $continue_label = null;
   for (; ; ) {
+    $continue_label = null;
     $j = 2;
     for (; ; ) {
       switch ($t) {
@@ -874,15 +855,12 @@ $h2 = function(dynamic $g, dynamic $t) use ($caml_call1) {
     }
     if ($continue_label === "a") {
       continue;
-    } else if ($continue_label !== null) {
-      break;
     }
   }
 };
 $h3 = function(dynamic $g, dynamic $t) use ($caml_call1) {
   $i = 4;
   for (; ; ) {
-    $continue_label = null;
     switch ($t) {
         // FALLTHROUGH
       case 0:
@@ -891,8 +869,8 @@ $h3 = function(dynamic $g, dynamic $t) use ($caml_call1) {
         // FALLTHROUGH
       case 1:
         $j = 4;
-        $continue_label = null;
         for (; ; ) {
+          $continue_label = null;
           $k = 2;
           for (; ; ) {
             $caml_call1($g, (int)((int)($i + $j) + $k));
@@ -911,12 +889,7 @@ $h3 = function(dynamic $g, dynamic $t) use ($caml_call1) {
           }
           if ($continue_label === "b") {
             continue;
-          } else if ($continue_label !== null) {
-            break;
           }
-          break;
-        }
-        if ($continue_label !== null) {
           break;
         }
         break;
@@ -924,9 +897,7 @@ $h3 = function(dynamic $g, dynamic $t) use ($caml_call1) {
       default:
         $caml_call1($g, 1);
     }
-    if ($continue_label === "switch") {
-      continue;
-    } else if ($continue_label !== null) {
+    if ($continue_label !== null) {
       break;
     }
     $G = (int)($i + 1);
@@ -945,8 +916,8 @@ $h4 = function(dynamic $g, dynamic $t) use ($caml_call1) {
       // FALLTHROUGH
     case 1:
       $j = 4;
-      $continue_label = null;
       for (; ; ) {
+        $continue_label = null;
         $k = 2;
         for (; ; ) {
           $caml_call1($g, (int)($j + $k));
@@ -965,12 +936,7 @@ $h4 = function(dynamic $g, dynamic $t) use ($caml_call1) {
         }
         if ($continue_label === "a") {
           continue;
-        } else if ($continue_label !== null) {
-          break;
         }
-      }
-      if ($continue_label !== null) {
-        break;
       }
       // FALLTHROUGH
     default:
@@ -979,11 +945,10 @@ $h4 = function(dynamic $g, dynamic $t) use ($caml_call1) {
 };
 $h5 = function(dynamic $g, dynamic $t) use ($caml_call1) {
   $i = 2;
-  $continue_label = null;
   for (; ; ) {
+    $continue_label = null;
     $j = 2;
     for (; ; ) {
-      $continue_label = null;
       switch ($t) {
           // FALLTHROUGH
         case 0:
@@ -992,8 +957,8 @@ $h5 = function(dynamic $g, dynamic $t) use ($caml_call1) {
           // FALLTHROUGH
         case 1:
           $k = 4;
-          $continue_label = null;
           for (; ; ) {
+            $continue_label = null;
             $l = 2;
             for (; ; ) {
               $caml_call1($g, (int)((int)($i + $j) + $k));
@@ -1012,12 +977,7 @@ $h5 = function(dynamic $g, dynamic $t) use ($caml_call1) {
             }
             if ($continue_label === "c") {
               continue;
-            } else if ($continue_label !== null) {
-              break;
             }
-            break;
-          }
-          if ($continue_label !== null) {
             break;
           }
           break;
@@ -1025,9 +985,7 @@ $h5 = function(dynamic $g, dynamic $t) use ($caml_call1) {
         default:
           $caml_call1($g, 1);
       }
-      if ($continue_label === "switch") {
-        continue;
-      } else if ($continue_label !== null) {
+      if ($continue_label !== null) {
         break;
       }
       $B = (int)($j + 1);
@@ -1045,8 +1003,6 @@ $h5 = function(dynamic $g, dynamic $t) use ($caml_call1) {
     }
     if ($continue_label === "a") {
       continue;
-    } else if ($continue_label !== null) {
-      break;
     }
   }
 };

--- a/rehack_tests/loop_labels/loop_labels.re
+++ b/rehack_tests/loop_labels/loop_labels.re
@@ -177,9 +177,7 @@ let h2 = (g, t) => {
     };
   };
 };
-/*
- - continue counter is never declared
- */
+/* no bug */
 let h3 = (g, t) => {
   for (i in 4 to 5) {
     switch (t) {

--- a/rehack_tests/static_react_bytecode/static-react-test.php
+++ b/rehack_tests/static_react_bytecode/static-react-test.php
@@ -2220,7 +2220,7 @@ $caml_wrap_thrown_exception_reraise = $caml_wrap_thrown_exception;
   
   $i__0 = 0;
   
-  $continue_counter = null;
+  $continue_label = null;
   for (;;) {
     $stateless = $element(Vector{0, $render__9($bq, 0)});
     $printSection($br);
@@ -2377,7 +2377,7 @@ $caml_wrap_thrown_exception_reraise = $caml_wrap_thrown_exception;
       );
       $printRoot($bW, $anotherPolyRoot);
       $bX = (int) ($i__0 + 1);
-      if (0 !== $i__0) {$i__0 = $bX;$continue_counter = 0;break;}
+      if (0 !== $i__0) {$i__0 = $bX;$continue_label = "a";break;}
       $endSeconds = $caml_sys_time(0);
       $log(
         $symbol(
@@ -2397,11 +2397,8 @@ $caml_wrap_thrown_exception_reraise = $caml_wrap_thrown_exception;
       }
       $do_at_exit(0);
     }
-    if ($continue_counter > 0) {
-      $continue_counter -= 1;
-      break;
-    }
-    else if ($continue_counter === 0) {$continue_counter = null;continue;}
+    if ($continue_label === "a") {continue;}
+    else if ($continue_label !== null) {break;}
   }
 
 }

--- a/rehack_tests/static_react_bytecode/static-react-test.php
+++ b/rehack_tests/static_react_bytecode/static-react-test.php
@@ -2220,8 +2220,8 @@ $caml_wrap_thrown_exception_reraise = $caml_wrap_thrown_exception;
   
   $i__0 = 0;
   
-  $continue_label = null;
   for (;;) {
+    $continue_label = null;
     $stateless = $element(Vector{0, $render__9($bq, 0)});
     $printSection($br);
     $containerRoot = $create(0);
@@ -2398,7 +2398,6 @@ $caml_wrap_thrown_exception_reraise = $caml_wrap_thrown_exception;
       $do_at_exit(0);
     }
     if ($continue_label === "a") {continue;}
-    else if ($continue_label !== null) {break;}
   }
 
 }

--- a/rehack_tests/stdlib/stdlib.cma.php/Array.php
+++ b/rehack_tests/stdlib/stdlib.cma.php/Array.php
@@ -596,7 +596,7 @@ final class Array_ {
         $c = 0;
         if (! ($d < 0)) {
           $i = $c;
-          $continue_counter = null;
+          $continue_label = null;
           for (;;) {
             $e = (int) ($srcofs + $i);
             $e__0 = $caml_check_bound($a, $e)[$e + 1];
@@ -618,17 +618,11 @@ final class Array_ {
               $j = (int) ($j[1] + 1);
               $caml_check_bound($dst, $j)[$j + 1] = $e__0;
               $k = (int) ($i + 1);
-              if ($d !== $i) {$i = $k;$continue_counter = 0;break;}
+              if ($d !== $i) {$i = $k;$continue_label = "a";break;}
               break;
             }
-            if ($continue_counter > 0) {
-              $continue_counter -= 1;
-              break;
-            }
-            else if ($continue_counter === 0) {
-              $continue_counter = null;
-              continue;
-            }
+            if ($continue_label === "a") {continue;}
+            else if ($continue_label !== null) {break;}
             break;
           }
         }

--- a/rehack_tests/stdlib/stdlib.cma.php/Array.php
+++ b/rehack_tests/stdlib/stdlib.cma.php/Array.php
@@ -596,8 +596,8 @@ final class Array_ {
         $c = 0;
         if (! ($d < 0)) {
           $i = $c;
-          $continue_label = null;
           for (;;) {
+            $continue_label = null;
             $e = (int) ($srcofs + $i);
             $e__0 = $caml_check_bound($a, $e)[$e + 1];
             $j = Vector{0, (int) ((int) ($dstofs + $i) + -1)};
@@ -622,7 +622,6 @@ final class Array_ {
               break;
             }
             if ($continue_label === "a") {continue;}
-            else if ($continue_label !== null) {break;}
             break;
           }
         }

--- a/rehack_tests/stdlib/stdlib.cma.php/CamlinternalFormat.php
+++ b/rehack_tests/stdlib/stdlib.cma.php/CamlinternalFormat.php
@@ -1260,49 +1260,49 @@ final class CamlinternalFormat {
               $fmtty__1 = $fmtty__0[1];
               $buffer_add_string($buf, $cst_c);
               $fmtty__0 = $fmtty__1;
-              $continue_label = "switch";break;
+              $continue_label = "#";break;
             // FALLTHROUGH
             case 1:
               $fmtty__2 = $fmtty__0[1];
               $buffer_add_string($buf, $cst_s);
               $fmtty__0 = $fmtty__2;
-              $continue_label = "switch";break;
+              $continue_label = "#";break;
             // FALLTHROUGH
             case 2:
               $fmtty__3 = $fmtty__0[1];
               $buffer_add_string($buf, $cst_i);
               $fmtty__0 = $fmtty__3;
-              $continue_label = "switch";break;
+              $continue_label = "#";break;
             // FALLTHROUGH
             case 3:
               $fmtty__4 = $fmtty__0[1];
               $buffer_add_string($buf, $cst_li);
               $fmtty__0 = $fmtty__4;
-              $continue_label = "switch";break;
+              $continue_label = "#";break;
             // FALLTHROUGH
             case 4:
               $fmtty__5 = $fmtty__0[1];
               $buffer_add_string($buf, $cst_ni);
               $fmtty__0 = $fmtty__5;
-              $continue_label = "switch";break;
+              $continue_label = "#";break;
             // FALLTHROUGH
             case 5:
               $fmtty__6 = $fmtty__0[1];
               $buffer_add_string($buf, $cst_Li);
               $fmtty__0 = $fmtty__6;
-              $continue_label = "switch";break;
+              $continue_label = "#";break;
             // FALLTHROUGH
             case 6:
               $fmtty__7 = $fmtty__0[1];
               $buffer_add_string($buf, $cst_f);
               $fmtty__0 = $fmtty__7;
-              $continue_label = "switch";break;
+              $continue_label = "#";break;
             // FALLTHROUGH
             case 7:
               $fmtty__8 = $fmtty__0[1];
               $buffer_add_string($buf, $cst_B);
               $fmtty__0 = $fmtty__8;
-              $continue_label = "switch";break;
+              $continue_label = "#";break;
             // FALLTHROUGH
             case 8:
               $fmtty__9 = $fmtty__0[2];
@@ -1311,7 +1311,7 @@ final class CamlinternalFormat {
               $bprint_fmtty->contents($buf, $sub_fmtty);
               $buffer_add_string($buf, $cst__10);
               $fmtty__0 = $fmtty__9;
-              $continue_label = "switch";break;
+              $continue_label = "#";break;
             // FALLTHROUGH
             case 9:
               $fmtty__10 = $fmtty__0[3];
@@ -1320,39 +1320,39 @@ final class CamlinternalFormat {
               $bprint_fmtty->contents($buf, $sub_fmtty__0);
               $buffer_add_string($buf, $cst__12);
               $fmtty__0 = $fmtty__10;
-              $continue_label = "switch";break;
+              $continue_label = "#";break;
             // FALLTHROUGH
             case 10:
               $fmtty__11 = $fmtty__0[1];
               $buffer_add_string($buf, $cst_a);
               $fmtty__0 = $fmtty__11;
-              $continue_label = "switch";break;
+              $continue_label = "#";break;
             // FALLTHROUGH
             case 11:
               $fmtty__12 = $fmtty__0[1];
               $buffer_add_string($buf, $cst_t);
               $fmtty__0 = $fmtty__12;
-              $continue_label = "switch";break;
+              $continue_label = "#";break;
             // FALLTHROUGH
             case 12:
               $fmtty__13 = $fmtty__0[1];
               $buffer_add_string($buf, $cst__13);
               $fmtty__0 = $fmtty__13;
-              $continue_label = "switch";break;
+              $continue_label = "#";break;
             // FALLTHROUGH
             case 13:
               $fmtty__14 = $fmtty__0[1];
               $buffer_add_string($buf, $cst_r);
               $fmtty__0 = $fmtty__14;
-              $continue_label = "switch";break;
+              $continue_label = "#";break;
             // FALLTHROUGH
             default:
               $fmtty__15 = $fmtty__0[1];
               $buffer_add_string($buf, $cst_r__0);
               $fmtty__0 = $fmtty__15;
-              $continue_label = "switch";break;
+              $continue_label = "#";break;
             }
-          if ($continue_label === "switch") {continue;}
+          if ($continue_label === "#") {continue;}
         }
       }
     };
@@ -1380,7 +1380,7 @@ final class CamlinternalFormat {
                 $buffer_add_char($buf, 99);
                 $fmt__0 = $fmt__1;
                 $ign_flag__0 = 0;
-                $continue_label = "switch";break;
+                $continue_label = "#";break;
               // FALLTHROUGH
               case 1:
                 $fmt__2 = $fmt__0[1];
@@ -1389,7 +1389,7 @@ final class CamlinternalFormat {
                 $buffer_add_char($buf, 67);
                 $fmt__0 = $fmt__2;
                 $ign_flag__0 = 0;
-                $continue_label = "switch";break;
+                $continue_label = "#";break;
               // FALLTHROUGH
               case 2:
                 $fmt__3 = $fmt__0[2];
@@ -1400,7 +1400,7 @@ final class CamlinternalFormat {
                 $buffer_add_char($buf, 115);
                 $fmt__0 = $fmt__3;
                 $ign_flag__0 = 0;
-                $continue_label = "switch";break;
+                $continue_label = "#";break;
               // FALLTHROUGH
               case 3:
                 $fmt__4 = $fmt__0[2];
@@ -1411,7 +1411,7 @@ final class CamlinternalFormat {
                 $buffer_add_char($buf, 83);
                 $fmt__0 = $fmt__4;
                 $ign_flag__0 = 0;
-                $continue_label = "switch";break;
+                $continue_label = "#";break;
               // FALLTHROUGH
               case 4:
                 $fmt__5 = $fmt__0[4];
@@ -1421,7 +1421,7 @@ final class CamlinternalFormat {
                 $bprint_int_fmt($buf, $ign_flag__0, $iconv, $pad__1, $prec);
                 $fmt__0 = $fmt__5;
                 $ign_flag__0 = 0;
-                $continue_label = "switch";break;
+                $continue_label = "#";break;
               // FALLTHROUGH
               case 5:
                 $fmt__6 = $fmt__0[4];
@@ -1438,7 +1438,7 @@ final class CamlinternalFormat {
                 );
                 $fmt__0 = $fmt__6;
                 $ign_flag__0 = 0;
-                $continue_label = "switch";break;
+                $continue_label = "#";break;
               // FALLTHROUGH
               case 6:
                 $fmt__7 = $fmt__0[4];
@@ -1455,7 +1455,7 @@ final class CamlinternalFormat {
                 );
                 $fmt__0 = $fmt__7;
                 $ign_flag__0 = 0;
-                $continue_label = "switch";break;
+                $continue_label = "#";break;
               // FALLTHROUGH
               case 7:
                 $fmt__8 = $fmt__0[4];
@@ -1472,7 +1472,7 @@ final class CamlinternalFormat {
                 );
                 $fmt__0 = $fmt__8;
                 $ign_flag__0 = 0;
-                $continue_label = "switch";break;
+                $continue_label = "#";break;
               // FALLTHROUGH
               case 8:
                 $fmt__9 = $fmt__0[4];
@@ -1488,7 +1488,7 @@ final class CamlinternalFormat {
                 );
                 $fmt__0 = $fmt__9;
                 $ign_flag__0 = 0;
-                $continue_label = "switch";break;
+                $continue_label = "#";break;
               // FALLTHROUGH
               case 9:
                 $fmt__10 = $fmt__0[2];
@@ -1499,27 +1499,27 @@ final class CamlinternalFormat {
                 $buffer_add_char($buf, 66);
                 $fmt__0 = $fmt__10;
                 $ign_flag__0 = 0;
-                $continue_label = "switch";break;
+                $continue_label = "#";break;
               // FALLTHROUGH
               case 10:
                 $fmt__11 = $fmt__0[1];
                 $buffer_add_string($buf, $cst__14);
                 $fmt__0 = $fmt__11;
-                $continue_label = "switch";break;
+                $continue_label = "#";break;
               // FALLTHROUGH
               case 11:
                 $fmt__12 = $fmt__0[2];
                 $str = $fmt__0[1];
                 $bprint_string_literal($buf, $str);
                 $fmt__0 = $fmt__12;
-                $continue_label = "switch";break;
+                $continue_label = "#";break;
               // FALLTHROUGH
               case 12:
                 $fmt__13 = $fmt__0[2];
                 $chr = $fmt__0[1];
                 $bprint_char_literal($buf, $chr);
                 $fmt__0 = $fmt__13;
-                $continue_label = "switch";break;
+                $continue_label = "#";break;
               // FALLTHROUGH
               case 13:
                 $fmt__14 = $fmt__0[3];
@@ -1534,7 +1534,7 @@ final class CamlinternalFormat {
                 $buffer_add_char($buf, 125);
                 $fmt__0 = $fmt__14;
                 $ign_flag__0 = 0;
-                $continue_label = "switch";break;
+                $continue_label = "#";break;
               // FALLTHROUGH
               case 14:
                 $fmt__15 = $fmt__0[3];
@@ -1549,7 +1549,7 @@ final class CamlinternalFormat {
                 $buffer_add_char($buf, 41);
                 $fmt__0 = $fmt__15;
                 $ign_flag__0 = 0;
-                $continue_label = "switch";break;
+                $continue_label = "#";break;
               // FALLTHROUGH
               case 15:
                 $fmt__16 = $fmt__0[1];
@@ -1558,7 +1558,7 @@ final class CamlinternalFormat {
                 $buffer_add_char($buf, 97);
                 $fmt__0 = $fmt__16;
                 $ign_flag__0 = 0;
-                $continue_label = "switch";break;
+                $continue_label = "#";break;
               // FALLTHROUGH
               case 16:
                 $fmt__17 = $fmt__0[1];
@@ -1567,7 +1567,7 @@ final class CamlinternalFormat {
                 $buffer_add_char($buf, 116);
                 $fmt__0 = $fmt__17;
                 $ign_flag__0 = 0;
-                $continue_label = "switch";break;
+                $continue_label = "#";break;
               // FALLTHROUGH
               case 17:
                 $fmt__18 = $fmt__0[2];
@@ -1577,7 +1577,7 @@ final class CamlinternalFormat {
                   $string_of_formatting_lit($fmting_lit)
                 );
                 $fmt__0 = $fmt__18;
-                $continue_label = "switch";break;
+                $continue_label = "#";break;
               // FALLTHROUGH
               case 18:
                 $fmt__19 = $fmt__0[2];
@@ -1588,7 +1588,7 @@ final class CamlinternalFormat {
                   $string_of_formatting_gen($fmting_gen)
                 );
                 $fmt__0 = $fmt__19;
-                $continue_label = "switch";break;
+                $continue_label = "#";break;
               // FALLTHROUGH
               case 19:
                 $fmt__20 = $fmt__0[1];
@@ -1597,7 +1597,7 @@ final class CamlinternalFormat {
                 $buffer_add_char($buf, 114);
                 $fmt__0 = $fmt__20;
                 $ign_flag__0 = 0;
-                $continue_label = "switch";break;
+                $continue_label = "#";break;
               // FALLTHROUGH
               case 20:
                 $fmt__21 = $fmt__0[3];
@@ -1609,7 +1609,7 @@ final class CamlinternalFormat {
                 $bprint_char_set($buf, $char_set);
                 $fmt__0 = $fmt__21;
                 $ign_flag__0 = 0;
-                $continue_label = "switch";break;
+                $continue_label = "#";break;
               // FALLTHROUGH
               case 21:
                 $fmt__22 = $fmt__0[2];
@@ -1619,7 +1619,7 @@ final class CamlinternalFormat {
                 $buffer_add_char($buf, $char_of_counter($counter));
                 $fmt__0 = $fmt__22;
                 $ign_flag__0 = 0;
-                $continue_label = "switch";break;
+                $continue_label = "#";break;
               // FALLTHROUGH
               case 22:
                 $fmt__23 = $fmt__0[1];
@@ -1628,7 +1628,7 @@ final class CamlinternalFormat {
                 $bprint_string_literal($buf, $cst_0c);
                 $fmt__0 = $fmt__23;
                 $ign_flag__0 = 0;
-                $continue_label = "switch";break;
+                $continue_label = "#";break;
               // FALLTHROUGH
               case 23:
                 $rest = $fmt__0[2];
@@ -1637,7 +1637,7 @@ final class CamlinternalFormat {
                 $fmt__24 = $match[1];
                 $fmt__0 = $fmt__24;
                 $ign_flag__0 = 1;
-                $continue_label = "switch";break;
+                $continue_label = "#";break;
               // FALLTHROUGH
               default:
                 $rest__0 = $fmt__0[3];
@@ -1657,9 +1657,9 @@ final class CamlinternalFormat {
                 }
                 $fmt__0 = $rest__0;
                 $ign_flag__0 = 0;
-                $continue_label = "switch";break;
+                $continue_label = "#";break;
               }
-            if ($continue_label === "switch") {continue;}
+            if ($continue_label === "#") {continue;}
           }
         }
       };
@@ -2958,17 +2958,17 @@ final class CamlinternalFormat {
             case 10:
               $fmtty__1 = $fmtty__0[1];
               $fmtty__0 = $fmtty__1;
-              $continue_label = "switch";break;
+              $continue_label = "#";break;
             // FALLTHROUGH
             case 11:
               $fmtty__2 = $fmtty__0[2];
               $fmtty__0 = $fmtty__2;
-              $continue_label = "switch";break;
+              $continue_label = "#";break;
             // FALLTHROUGH
             case 12:
               $fmtty__3 = $fmtty__0[2];
               $fmtty__0 = $fmtty__3;
-              $continue_label = "switch";break;
+              $continue_label = "#";break;
             // FALLTHROUGH
             case 13:
               $rest__9 = $fmtty__0[3];
@@ -2996,7 +2996,7 @@ final class CamlinternalFormat {
             case 17:
               $fmtty__4 = $fmtty__0[2];
               $fmtty__0 = $fmtty__4;
-              $continue_label = "switch";break;
+              $continue_label = "#";break;
             // FALLTHROUGH
             case 18:
               $rest__13 = $fmtty__0[2];
@@ -3045,7 +3045,7 @@ final class CamlinternalFormat {
                 $fmtty_of_fmt->contents($rest__19)
               );
             }
-          if ($continue_label === "switch") {continue;}
+          if ($continue_label === "#") {continue;}
         }
       }
     };
@@ -4836,7 +4836,7 @@ final class CamlinternalFormat {
               $acc__1 = Vector{7, $acc__0};
               $acc__0 = $acc__1;
               $fmt__0 = $fmt__1;
-              $continue_label = "switch";break;
+              $continue_label = "#";break;
             // FALLTHROUGH
             case 11:
               $fmt__2 = $fmt__0[2];
@@ -4844,7 +4844,7 @@ final class CamlinternalFormat {
               $acc__2 = Vector{2, $acc__0, $str};
               $acc__0 = $acc__2;
               $fmt__0 = $fmt__2;
-              $continue_label = "switch";break;
+              $continue_label = "#";break;
             // FALLTHROUGH
             case 12:
               $fmt__3 = $fmt__0[2];
@@ -4852,7 +4852,7 @@ final class CamlinternalFormat {
               $acc__3 = Vector{3, $acc__0, $chr};
               $acc__0 = $acc__3;
               $fmt__0 = $fmt__3;
-              $continue_label = "switch";break;
+              $continue_label = "#";break;
             // FALLTHROUGH
             case 13:
               $rest__9 = $fmt__0[3];
@@ -4915,7 +4915,7 @@ final class CamlinternalFormat {
               $acc__4 = Vector{0, $acc__0, $fmting_lit};
               $acc__0 = $acc__4;
               $fmt__0 = $fmt__4;
-              $continue_label = "switch";break;
+              $continue_label = "#";break;
             // FALLTHROUGH
             case 18:
               $cU = $fmt__0[1];
@@ -4938,7 +4938,7 @@ final class CamlinternalFormat {
                 $k__0 = $k__1;
                 $acc__0 = 0;
                 $fmt__0 = $fmt__5;
-                $continue_label = "switch";break;
+                $continue_label = "#";break;
               }
               $rest__14 = $fmt__0[2];
               $match__0 = $cU[1];
@@ -4958,7 +4958,7 @@ final class CamlinternalFormat {
               $k__0 = $k__2;
               $acc__0 = 0;
               $fmt__0 = $fmt__6;
-              $continue_label = "switch";break;
+              $continue_label = "#";break;
             // FALLTHROUGH
             case 19:
               throw $runtime["caml_wrap_thrown_exception"](Vector{0, $Assert_failure, $q}) as \Throwable;
@@ -5025,7 +5025,7 @@ final class CamlinternalFormat {
                 varray[0,$k__0,$o,$acc__0,$rest__19,$arity,$cV]
               );
             }
-          if ($continue_label === "switch") {continue;}
+          if ($continue_label === "#") {continue;}
         }
       }
     };
@@ -5693,17 +5693,17 @@ final class CamlinternalFormat {
             case 10:
               $fmt__1 = $fmt__0[1];
               $fmt__0 = $fmt__1;
-              $continue_label = "switch";break;
+              $continue_label = "#";break;
             // FALLTHROUGH
             case 11:
               $fmt__2 = $fmt__0[2];
               $fmt__0 = $fmt__2;
-              $continue_label = "switch";break;
+              $continue_label = "#";break;
             // FALLTHROUGH
             case 12:
               $fmt__3 = $fmt__0[2];
               $fmt__0 = $fmt__3;
-              $continue_label = "switch";break;
+              $continue_label = "#";break;
             // FALLTHROUGH
             case 13:
               $rest__15 = $fmt__0[3];
@@ -5745,7 +5745,7 @@ final class CamlinternalFormat {
             case 17:
               $fmt__4 = $fmt__0[2];
               $fmt__0 = $fmt__4;
-              $continue_label = "switch";break;
+              $continue_label = "#";break;
             // FALLTHROUGH
             case 18:
               $bX = $fmt__0[1];
@@ -5762,7 +5762,7 @@ final class CamlinternalFormat {
                 $k__1 = $k__3($k__0, $rest__19);
                 $k__0 = $k__1;
                 $fmt__0 = $fmt__5;
-                $continue_label = "switch";break;
+                $continue_label = "#";break;
               }
               $rest__20 = $fmt__0[2];
               $match__0 = $bX[1];
@@ -5776,7 +5776,7 @@ final class CamlinternalFormat {
               $k__2 = $k__4($k__0, $rest__20);
               $k__0 = $k__2;
               $fmt__0 = $fmt__6;
-              $continue_label = "switch";break;
+              $continue_label = "#";break;
             // FALLTHROUGH
             case 19:
               throw $runtime["caml_wrap_thrown_exception"](Vector{0, $Assert_failure, $u}) as \Throwable;
@@ -5834,7 +5834,7 @@ final class CamlinternalFormat {
                 varray[0,$k__0,$o,$rest__25,$arity]
               );
             }
-          if ($continue_label === "switch") {continue;}
+          if ($continue_label === "#") {continue;}
         }
       }
     };
@@ -5885,13 +5885,13 @@ final class CamlinternalFormat {
                 $output_acc->contents($o, $bz);
                 $call2($Pervasives[54], $o, $cst__17);
                 $acc__0 = $acc__1;
-                $continue_label = "switch";break;
+                $continue_label = "#";break;
               }
               $acc__2 = $by[1];
               $output_acc->contents($o, $bz);
               $call2($Pervasives[54], $o, $cst__18);
               $acc__0 = $acc__2;
-              $continue_label = "switch";break;
+              $continue_label = "#";break;
             // FALLTHROUGH
             case 6:
               $f = $acc__0[2];
@@ -5924,7 +5924,7 @@ final class CamlinternalFormat {
               $output_acc->contents($o, $p__1);
               return $call2($Pervasives[53], $o, $c);
             }
-          if ($continue_label === "switch") {continue;}
+          if ($continue_label === "#") {continue;}
         }
       }
     };
@@ -5951,13 +5951,13 @@ final class CamlinternalFormat {
                 $bufput_acc->contents($b, $bx);
                 $call2($Buffer[14], $b, $cst__19);
                 $acc__0 = $acc__1;
-                $continue_label = "switch";break;
+                $continue_label = "#";break;
               }
               $acc__2 = $bw[1];
               $bufput_acc->contents($b, $bx);
               $call2($Buffer[14], $b, $cst__20);
               $acc__0 = $acc__2;
-              $continue_label = "switch";break;
+              $continue_label = "#";break;
             // FALLTHROUGH
             case 6:
               $f = $acc__0[2];
@@ -5968,7 +5968,7 @@ final class CamlinternalFormat {
             case 7:
               $acc__3 = $acc__0[1];
               $acc__0 = $acc__3;
-              $continue_label = "switch";break;
+              $continue_label = "#";break;
             // FALLTHROUGH
             case 8:
               $msg = $acc__0[2];
@@ -5990,7 +5990,7 @@ final class CamlinternalFormat {
               $bufput_acc->contents($b, $p__1);
               return $call2($Buffer[10], $b, $c);
             }
-          if ($continue_label === "switch") {continue;}
+          if ($continue_label === "#") {continue;}
         }
       }
     };
@@ -6017,13 +6017,13 @@ final class CamlinternalFormat {
                 $strput_acc->contents($b, $bu);
                 $call2($Buffer[14], $b, $cst__21);
                 $acc__0 = $acc__1;
-                $continue_label = "switch";break;
+                $continue_label = "#";break;
               }
               $acc__2 = $bt[1];
               $strput_acc->contents($b, $bu);
               $call2($Buffer[14], $b, $cst__22);
               $acc__0 = $acc__2;
-              $continue_label = "switch";break;
+              $continue_label = "#";break;
             // FALLTHROUGH
             case 6:
               $f = $acc__0[2];
@@ -6035,7 +6035,7 @@ final class CamlinternalFormat {
             case 7:
               $acc__3 = $acc__0[1];
               $acc__0 = $acc__3;
-              $continue_label = "switch";break;
+              $continue_label = "#";break;
             // FALLTHROUGH
             case 8:
               $msg = $acc__0[2];
@@ -6057,7 +6057,7 @@ final class CamlinternalFormat {
               $strput_acc->contents($b, $p__1);
               return $call2($Buffer[10], $b, $c);
             }
-          if ($continue_label === "switch") {continue;}
+          if ($continue_label === "#") {continue;}
         }
       }
     };
@@ -6311,33 +6311,33 @@ final class CamlinternalFormat {
                   $set_flag($str_ind__0, $space);
                   $str_ind__1 = (int) ($str_ind__0 + 1);
                   $str_ind__0 = $str_ind__1;
-                  $continue_label = "switch";break;
+                  $continue_label = "#";break;
                 // FALLTHROUGH
                 case 3:
                   $set_flag($str_ind__0, $hash);
                   $str_ind__2 = (int) ($str_ind__0 + 1);
                   $str_ind__0 = $str_ind__2;
-                  $continue_label = "switch";break;
+                  $continue_label = "#";break;
                 // FALLTHROUGH
                 case 11:
                   $set_flag($str_ind__0, $plus);
                   $str_ind__3 = (int) ($str_ind__0 + 1);
                   $str_ind__0 = $str_ind__3;
-                  $continue_label = "switch";break;
+                  $continue_label = "#";break;
                 // FALLTHROUGH
                 case 13:
                   $set_flag($str_ind__0, $minus);
                   $str_ind__4 = (int) ($str_ind__0 + 1);
                   $str_ind__0 = $str_ind__4;
-                  $continue_label = "switch";break;
+                  $continue_label = "#";break;
                 // FALLTHROUGH
                 case 16:
                   $set_flag($str_ind__0, $zero);
                   $str_ind__5 = (int) ($str_ind__0 + 1);
                   $str_ind__0 = $str_ind__5;
-                  $continue_label = "switch";break;
+                  $continue_label = "#";break;
                 }
-              if ($continue_label === "switch") {continue;}
+              if ($continue_label === "#") {continue;}
             }
             return $parse_padding->contents(
               $pct_ind,
@@ -7875,7 +7875,7 @@ final class CamlinternalFormat {
                       );
                       $str_ind__2 = (int) ($sub_end + 2);
                       $str_ind__0 = $str_ind__2;
-                      $continue_label = "switch";break;
+                      $continue_label = "#";break;
                     // FALLTHROUGH
                     case 1:break;
                     // FALLTHROUGH
@@ -7887,7 +7887,7 @@ final class CamlinternalFormat {
                         125
                       );
                     }
-                  if ($continue_label === "switch") {continue;}
+                  if ($continue_label === "#") {continue;}
                 }
               }
               else {
@@ -8099,7 +8099,7 @@ final class CamlinternalFormat {
                 case 29:
                   if ($legacy_behavior__0) {
                     $hash__0 = 0;
-                    $continue_label = "switch";break;
+                    $continue_label = "#";break;
                   }
                   return $incompatible_flag->contents(
                     $pct_ind,
@@ -8108,7 +8108,7 @@ final class CamlinternalFormat {
                     $cst__36
                   );
                 }
-              if ($continue_label === "switch") {continue;}
+              if ($continue_label === "#") {continue;}
             }
           }
           if (0 === $plus__0) {

--- a/rehack_tests/stdlib/stdlib.cma.php/CamlinternalFormat.php
+++ b/rehack_tests/stdlib/stdlib.cma.php/CamlinternalFormat.php
@@ -1250,105 +1250,109 @@ final class CamlinternalFormat {
     };
     $bprint_fmtty->contents = function(dynamic $buf, dynamic $fmtty) use ($bprint_fmtty,$buffer_add_string,$cst_B,$cst_Li,$cst__10,$cst__11,$cst__12,$cst__13,$cst__9,$cst_a,$cst_c,$cst_f,$cst_i,$cst_li,$cst_ni,$cst_r,$cst_r__0,$cst_s,$cst_t,$is_int) {
       $fmtty__0 = $fmtty;
-      for (;;) if (
-        $is_int($fmtty__0)
-      ) {return 0;}
-      else {
-        if ($fmtty__0[0] === 0) {
-          $fmtty__1 = $fmtty__0[1];
-          $buffer_add_string($buf, $cst_c);
-          $fmtty__0 = $fmtty__1;
-          continue;
-        }
-        else if ($fmtty__0[0] === 1) {
-          $fmtty__2 = $fmtty__0[1];
-          $buffer_add_string($buf, $cst_s);
-          $fmtty__0 = $fmtty__2;
-          continue;
-        }
-        else if ($fmtty__0[0] === 2) {
-          $fmtty__3 = $fmtty__0[1];
-          $buffer_add_string($buf, $cst_i);
-          $fmtty__0 = $fmtty__3;
-          continue;
-        }
-        else if ($fmtty__0[0] === 3) {
-          $fmtty__4 = $fmtty__0[1];
-          $buffer_add_string($buf, $cst_li);
-          $fmtty__0 = $fmtty__4;
-          continue;
-        }
-        else if ($fmtty__0[0] === 4) {
-          $fmtty__5 = $fmtty__0[1];
-          $buffer_add_string($buf, $cst_ni);
-          $fmtty__0 = $fmtty__5;
-          continue;
-        }
-        else if ($fmtty__0[0] === 5) {
-          $fmtty__6 = $fmtty__0[1];
-          $buffer_add_string($buf, $cst_Li);
-          $fmtty__0 = $fmtty__6;
-          continue;
-        }
-        else if ($fmtty__0[0] === 6) {
-          $fmtty__7 = $fmtty__0[1];
-          $buffer_add_string($buf, $cst_f);
-          $fmtty__0 = $fmtty__7;
-          continue;
-        }
-        else if ($fmtty__0[0] === 7) {
-          $fmtty__8 = $fmtty__0[1];
-          $buffer_add_string($buf, $cst_B);
-          $fmtty__0 = $fmtty__8;
-          continue;
-        }
-        else if ($fmtty__0[0] === 8) {
-          $fmtty__9 = $fmtty__0[2];
-          $sub_fmtty = $fmtty__0[1];
-          $buffer_add_string($buf, $cst__9);
-          $bprint_fmtty->contents($buf, $sub_fmtty);
-          $buffer_add_string($buf, $cst__10);
-          $fmtty__0 = $fmtty__9;
-          continue;
-        }
-        else if ($fmtty__0[0] === 9) {
-          $fmtty__10 = $fmtty__0[3];
-          $sub_fmtty__0 = $fmtty__0[1];
-          $buffer_add_string($buf, $cst__11);
-          $bprint_fmtty->contents($buf, $sub_fmtty__0);
-          $buffer_add_string($buf, $cst__12);
-          $fmtty__0 = $fmtty__10;
-          continue;
-        }
-        else if ($fmtty__0[0] === 10) {
-          $fmtty__11 = $fmtty__0[1];
-          $buffer_add_string($buf, $cst_a);
-          $fmtty__0 = $fmtty__11;
-          continue;
-        }
-        else if ($fmtty__0[0] === 11) {
-          $fmtty__12 = $fmtty__0[1];
-          $buffer_add_string($buf, $cst_t);
-          $fmtty__0 = $fmtty__12;
-          continue;
-        }
-        else if ($fmtty__0[0] === 12) {
-          $fmtty__13 = $fmtty__0[1];
-          $buffer_add_string($buf, $cst__13);
-          $fmtty__0 = $fmtty__13;
-          continue;
-        }
-        else if ($fmtty__0[0] === 13) {
-          $fmtty__14 = $fmtty__0[1];
-          $buffer_add_string($buf, $cst_r);
-          $fmtty__0 = $fmtty__14;
-          continue;
-        }
+      for (;;) {
+        if ($is_int($fmtty__0)) {return 0;}
         else {
-          $fmtty__15 = $fmtty__0[1];
-          $buffer_add_string($buf, $cst_r__0);
-          $fmtty__0 = $fmtty__15;
-          continue;
+          $continue_label = null;
+          switch($fmtty__0[0]) {
+            // FALLTHROUGH
+            case 0:
+              $fmtty__1 = $fmtty__0[1];
+              $buffer_add_string($buf, $cst_c);
+              $fmtty__0 = $fmtty__1;
+              $continue_label = "switch";break;
+            // FALLTHROUGH
+            case 1:
+              $fmtty__2 = $fmtty__0[1];
+              $buffer_add_string($buf, $cst_s);
+              $fmtty__0 = $fmtty__2;
+              $continue_label = "switch";break;
+            // FALLTHROUGH
+            case 2:
+              $fmtty__3 = $fmtty__0[1];
+              $buffer_add_string($buf, $cst_i);
+              $fmtty__0 = $fmtty__3;
+              $continue_label = "switch";break;
+            // FALLTHROUGH
+            case 3:
+              $fmtty__4 = $fmtty__0[1];
+              $buffer_add_string($buf, $cst_li);
+              $fmtty__0 = $fmtty__4;
+              $continue_label = "switch";break;
+            // FALLTHROUGH
+            case 4:
+              $fmtty__5 = $fmtty__0[1];
+              $buffer_add_string($buf, $cst_ni);
+              $fmtty__0 = $fmtty__5;
+              $continue_label = "switch";break;
+            // FALLTHROUGH
+            case 5:
+              $fmtty__6 = $fmtty__0[1];
+              $buffer_add_string($buf, $cst_Li);
+              $fmtty__0 = $fmtty__6;
+              $continue_label = "switch";break;
+            // FALLTHROUGH
+            case 6:
+              $fmtty__7 = $fmtty__0[1];
+              $buffer_add_string($buf, $cst_f);
+              $fmtty__0 = $fmtty__7;
+              $continue_label = "switch";break;
+            // FALLTHROUGH
+            case 7:
+              $fmtty__8 = $fmtty__0[1];
+              $buffer_add_string($buf, $cst_B);
+              $fmtty__0 = $fmtty__8;
+              $continue_label = "switch";break;
+            // FALLTHROUGH
+            case 8:
+              $fmtty__9 = $fmtty__0[2];
+              $sub_fmtty = $fmtty__0[1];
+              $buffer_add_string($buf, $cst__9);
+              $bprint_fmtty->contents($buf, $sub_fmtty);
+              $buffer_add_string($buf, $cst__10);
+              $fmtty__0 = $fmtty__9;
+              $continue_label = "switch";break;
+            // FALLTHROUGH
+            case 9:
+              $fmtty__10 = $fmtty__0[3];
+              $sub_fmtty__0 = $fmtty__0[1];
+              $buffer_add_string($buf, $cst__11);
+              $bprint_fmtty->contents($buf, $sub_fmtty__0);
+              $buffer_add_string($buf, $cst__12);
+              $fmtty__0 = $fmtty__10;
+              $continue_label = "switch";break;
+            // FALLTHROUGH
+            case 10:
+              $fmtty__11 = $fmtty__0[1];
+              $buffer_add_string($buf, $cst_a);
+              $fmtty__0 = $fmtty__11;
+              $continue_label = "switch";break;
+            // FALLTHROUGH
+            case 11:
+              $fmtty__12 = $fmtty__0[1];
+              $buffer_add_string($buf, $cst_t);
+              $fmtty__0 = $fmtty__12;
+              $continue_label = "switch";break;
+            // FALLTHROUGH
+            case 12:
+              $fmtty__13 = $fmtty__0[1];
+              $buffer_add_string($buf, $cst__13);
+              $fmtty__0 = $fmtty__13;
+              $continue_label = "switch";break;
+            // FALLTHROUGH
+            case 13:
+              $fmtty__14 = $fmtty__0[1];
+              $buffer_add_string($buf, $cst_r);
+              $fmtty__0 = $fmtty__14;
+              $continue_label = "switch";break;
+            // FALLTHROUGH
+            default:
+              $fmtty__15 = $fmtty__0[1];
+              $buffer_add_string($buf, $cst_r__0);
+              $fmtty__0 = $fmtty__15;
+              $continue_label = "switch";break;
+            }
+          if ($continue_label === "switch") {continue;}
         }
       }
     };
@@ -1363,289 +1367,299 @@ final class CamlinternalFormat {
       $fmtiter = function(dynamic $fmt, dynamic $ign_flag) use ($bprint_altint_fmt,$bprint_char_literal,$bprint_char_set,$bprint_float_fmt,$bprint_fmtty,$bprint_ignored_flag,$bprint_int_fmt,$bprint_pad_opt,$bprint_padding,$bprint_string_literal,$buf,$buffer_add_char,$buffer_add_string,$char_of_counter,$cst_0c,$cst__14,$cst__15,$int_of_custom_arity,$is_int,$param_format_of_ignored_format,$string_of_formatting_gen,$string_of_formatting_lit) {
         $fmt__0 = $fmt;
         $ign_flag__0 = $ign_flag;
-        for (;;) if (
-          $is_int($fmt__0)
-        ) {return 0;}
-        else {
-          if ($fmt__0[0] === 0) {
-            $fmt__1 = $fmt__0[1];
-            $buffer_add_char($buf, 37);
-            $bprint_ignored_flag($buf, $ign_flag__0);
-            $buffer_add_char($buf, 99);
-            $fmt__0 = $fmt__1;
-            $ign_flag__0 = 0;
-            continue;
-          }
-          else if ($fmt__0[0] === 1) {
-            $fmt__2 = $fmt__0[1];
-            $buffer_add_char($buf, 37);
-            $bprint_ignored_flag($buf, $ign_flag__0);
-            $buffer_add_char($buf, 67);
-            $fmt__0 = $fmt__2;
-            $ign_flag__0 = 0;
-            continue;
-          }
-          else if ($fmt__0[0] === 2) {
-            $fmt__3 = $fmt__0[2];
-            $pad = $fmt__0[1];
-            $buffer_add_char($buf, 37);
-            $bprint_ignored_flag($buf, $ign_flag__0);
-            $bprint_padding($buf, $pad);
-            $buffer_add_char($buf, 115);
-            $fmt__0 = $fmt__3;
-            $ign_flag__0 = 0;
-            continue;
-          }
-          else if ($fmt__0[0] === 3) {
-            $fmt__4 = $fmt__0[2];
-            $pad__0 = $fmt__0[1];
-            $buffer_add_char($buf, 37);
-            $bprint_ignored_flag($buf, $ign_flag__0);
-            $bprint_padding($buf, $pad__0);
-            $buffer_add_char($buf, 83);
-            $fmt__0 = $fmt__4;
-            $ign_flag__0 = 0;
-            continue;
-          }
-          else if ($fmt__0[0] === 4) {
-            $fmt__5 = $fmt__0[4];
-            $prec = $fmt__0[3];
-            $pad__1 = $fmt__0[2];
-            $iconv = $fmt__0[1];
-            $bprint_int_fmt($buf, $ign_flag__0, $iconv, $pad__1, $prec);
-            $fmt__0 = $fmt__5;
-            $ign_flag__0 = 0;
-            continue;
-          }
-          else if ($fmt__0[0] === 5) {
-            $fmt__6 = $fmt__0[4];
-            $prec__0 = $fmt__0[3];
-            $pad__2 = $fmt__0[2];
-            $iconv__0 = $fmt__0[1];
-            $bprint_altint_fmt(
-              $buf,
-              $ign_flag__0,
-              $iconv__0,
-              $pad__2,
-              $prec__0,
-              108
-            );
-            $fmt__0 = $fmt__6;
-            $ign_flag__0 = 0;
-            continue;
-          }
-          else if ($fmt__0[0] === 6) {
-            $fmt__7 = $fmt__0[4];
-            $prec__1 = $fmt__0[3];
-            $pad__3 = $fmt__0[2];
-            $iconv__1 = $fmt__0[1];
-            $bprint_altint_fmt(
-              $buf,
-              $ign_flag__0,
-              $iconv__1,
-              $pad__3,
-              $prec__1,
-              110
-            );
-            $fmt__0 = $fmt__7;
-            $ign_flag__0 = 0;
-            continue;
-          }
-          else if ($fmt__0[0] === 7) {
-            $fmt__8 = $fmt__0[4];
-            $prec__2 = $fmt__0[3];
-            $pad__4 = $fmt__0[2];
-            $iconv__2 = $fmt__0[1];
-            $bprint_altint_fmt(
-              $buf,
-              $ign_flag__0,
-              $iconv__2,
-              $pad__4,
-              $prec__2,
-              76
-            );
-            $fmt__0 = $fmt__8;
-            $ign_flag__0 = 0;
-            continue;
-          }
-          else if ($fmt__0[0] === 8) {
-            $fmt__9 = $fmt__0[4];
-            $prec__3 = $fmt__0[3];
-            $pad__5 = $fmt__0[2];
-            $fconv = $fmt__0[1];
-            $bprint_float_fmt($buf, $ign_flag__0, $fconv, $pad__5, $prec__3);
-            $fmt__0 = $fmt__9;
-            $ign_flag__0 = 0;
-            continue;
-          }
-          else if ($fmt__0[0] === 9) {
-            $fmt__10 = $fmt__0[2];
-            $pad__6 = $fmt__0[1];
-            $buffer_add_char($buf, 37);
-            $bprint_ignored_flag($buf, $ign_flag__0);
-            $bprint_padding($buf, $pad__6);
-            $buffer_add_char($buf, 66);
-            $fmt__0 = $fmt__10;
-            $ign_flag__0 = 0;
-            continue;
-          }
-          else if ($fmt__0[0] === 10) {
-            $fmt__11 = $fmt__0[1];
-            $buffer_add_string($buf, $cst__14);
-            $fmt__0 = $fmt__11;
-            continue;
-          }
-          else if ($fmt__0[0] === 11) {
-            $fmt__12 = $fmt__0[2];
-            $str = $fmt__0[1];
-            $bprint_string_literal($buf, $str);
-            $fmt__0 = $fmt__12;
-            continue;
-          }
-          else if ($fmt__0[0] === 12) {
-            $fmt__13 = $fmt__0[2];
-            $chr = $fmt__0[1];
-            $bprint_char_literal($buf, $chr);
-            $fmt__0 = $fmt__13;
-            continue;
-          }
-          else if ($fmt__0[0] === 13) {
-            $fmt__14 = $fmt__0[3];
-            $fmtty = $fmt__0[2];
-            $pad_opt = $fmt__0[1];
-            $buffer_add_char($buf, 37);
-            $bprint_ignored_flag($buf, $ign_flag__0);
-            $bprint_pad_opt($buf, $pad_opt);
-            $buffer_add_char($buf, 123);
-            $bprint_fmtty->contents($buf, $fmtty);
-            $buffer_add_char($buf, 37);
-            $buffer_add_char($buf, 125);
-            $fmt__0 = $fmt__14;
-            $ign_flag__0 = 0;
-            continue;
-          }
-          else if ($fmt__0[0] === 14) {
-            $fmt__15 = $fmt__0[3];
-            $fmtty__0 = $fmt__0[2];
-            $pad_opt__0 = $fmt__0[1];
-            $buffer_add_char($buf, 37);
-            $bprint_ignored_flag($buf, $ign_flag__0);
-            $bprint_pad_opt($buf, $pad_opt__0);
-            $buffer_add_char($buf, 40);
-            $bprint_fmtty->contents($buf, $fmtty__0);
-            $buffer_add_char($buf, 37);
-            $buffer_add_char($buf, 41);
-            $fmt__0 = $fmt__15;
-            $ign_flag__0 = 0;
-            continue;
-          }
-          else if ($fmt__0[0] === 15) {
-            $fmt__16 = $fmt__0[1];
-            $buffer_add_char($buf, 37);
-            $bprint_ignored_flag($buf, $ign_flag__0);
-            $buffer_add_char($buf, 97);
-            $fmt__0 = $fmt__16;
-            $ign_flag__0 = 0;
-            continue;
-          }
-          else if ($fmt__0[0] === 16) {
-            $fmt__17 = $fmt__0[1];
-            $buffer_add_char($buf, 37);
-            $bprint_ignored_flag($buf, $ign_flag__0);
-            $buffer_add_char($buf, 116);
-            $fmt__0 = $fmt__17;
-            $ign_flag__0 = 0;
-            continue;
-          }
-          else if ($fmt__0[0] === 17) {
-            $fmt__18 = $fmt__0[2];
-            $fmting_lit = $fmt__0[1];
-            $bprint_string_literal(
-              $buf,
-              $string_of_formatting_lit($fmting_lit)
-            );
-            $fmt__0 = $fmt__18;
-            continue;
-          }
-          else if ($fmt__0[0] === 18) {
-            $fmt__19 = $fmt__0[2];
-            $fmting_gen = $fmt__0[1];
-            $bprint_string_literal($buf, $cst__15);
-            $bprint_string_literal(
-              $buf,
-              $string_of_formatting_gen($fmting_gen)
-            );
-            $fmt__0 = $fmt__19;
-            continue;
-          }
-          else if ($fmt__0[0] === 19) {
-            $fmt__20 = $fmt__0[1];
-            $buffer_add_char($buf, 37);
-            $bprint_ignored_flag($buf, $ign_flag__0);
-            $buffer_add_char($buf, 114);
-            $fmt__0 = $fmt__20;
-            $ign_flag__0 = 0;
-            continue;
-          }
-          else if ($fmt__0[0] === 20) {
-            $fmt__21 = $fmt__0[3];
-            $char_set = $fmt__0[2];
-            $width_opt = $fmt__0[1];
-            $buffer_add_char($buf, 37);
-            $bprint_ignored_flag($buf, $ign_flag__0);
-            $bprint_pad_opt($buf, $width_opt);
-            $bprint_char_set($buf, $char_set);
-            $fmt__0 = $fmt__21;
-            $ign_flag__0 = 0;
-            continue;
-          }
-          else if ($fmt__0[0] === 21) {
-            $fmt__22 = $fmt__0[2];
-            $counter = $fmt__0[1];
-            $buffer_add_char($buf, 37);
-            $bprint_ignored_flag($buf, $ign_flag__0);
-            $buffer_add_char($buf, $char_of_counter($counter));
-            $fmt__0 = $fmt__22;
-            $ign_flag__0 = 0;
-            continue;
-          }
-          else if ($fmt__0[0] === 22) {
-            $fmt__23 = $fmt__0[1];
-            $buffer_add_char($buf, 37);
-            $bprint_ignored_flag($buf, $ign_flag__0);
-            $bprint_string_literal($buf, $cst_0c);
-            $fmt__0 = $fmt__23;
-            $ign_flag__0 = 0;
-            continue;
-          }
-          else if ($fmt__0[0] === 23) {
-            $rest = $fmt__0[2];
-            $ign = $fmt__0[1];
-            $match = $param_format_of_ignored_format($ign, $rest);
-            $fmt__24 = $match[1];
-            $fmt__0 = $fmt__24;
-            $ign_flag__0 = 1;
-            continue;
-          }
+        for (;;) {
+          if ($is_int($fmt__0)) {return 0;}
           else {
-            $rest__0 = $fmt__0[3];
-            $arity = $fmt__0[1];
-            $ep = $int_of_custom_arity->contents($arity);
-            $eo = 1;
-            if (! ($ep < 1)) {
-              $i = $eo;
-              for (;;) {
+            $continue_label = null;
+            switch($fmt__0[0]) {
+              // FALLTHROUGH
+              case 0:
+                $fmt__1 = $fmt__0[1];
                 $buffer_add_char($buf, 37);
                 $bprint_ignored_flag($buf, $ign_flag__0);
-                $buffer_add_char($buf, 63);
-                $eq = (int) ($i + 1);
-                if ($ep !== $i) {$i = $eq;continue;}
-                break;
+                $buffer_add_char($buf, 99);
+                $fmt__0 = $fmt__1;
+                $ign_flag__0 = 0;
+                $continue_label = "switch";break;
+              // FALLTHROUGH
+              case 1:
+                $fmt__2 = $fmt__0[1];
+                $buffer_add_char($buf, 37);
+                $bprint_ignored_flag($buf, $ign_flag__0);
+                $buffer_add_char($buf, 67);
+                $fmt__0 = $fmt__2;
+                $ign_flag__0 = 0;
+                $continue_label = "switch";break;
+              // FALLTHROUGH
+              case 2:
+                $fmt__3 = $fmt__0[2];
+                $pad = $fmt__0[1];
+                $buffer_add_char($buf, 37);
+                $bprint_ignored_flag($buf, $ign_flag__0);
+                $bprint_padding($buf, $pad);
+                $buffer_add_char($buf, 115);
+                $fmt__0 = $fmt__3;
+                $ign_flag__0 = 0;
+                $continue_label = "switch";break;
+              // FALLTHROUGH
+              case 3:
+                $fmt__4 = $fmt__0[2];
+                $pad__0 = $fmt__0[1];
+                $buffer_add_char($buf, 37);
+                $bprint_ignored_flag($buf, $ign_flag__0);
+                $bprint_padding($buf, $pad__0);
+                $buffer_add_char($buf, 83);
+                $fmt__0 = $fmt__4;
+                $ign_flag__0 = 0;
+                $continue_label = "switch";break;
+              // FALLTHROUGH
+              case 4:
+                $fmt__5 = $fmt__0[4];
+                $prec = $fmt__0[3];
+                $pad__1 = $fmt__0[2];
+                $iconv = $fmt__0[1];
+                $bprint_int_fmt($buf, $ign_flag__0, $iconv, $pad__1, $prec);
+                $fmt__0 = $fmt__5;
+                $ign_flag__0 = 0;
+                $continue_label = "switch";break;
+              // FALLTHROUGH
+              case 5:
+                $fmt__6 = $fmt__0[4];
+                $prec__0 = $fmt__0[3];
+                $pad__2 = $fmt__0[2];
+                $iconv__0 = $fmt__0[1];
+                $bprint_altint_fmt(
+                  $buf,
+                  $ign_flag__0,
+                  $iconv__0,
+                  $pad__2,
+                  $prec__0,
+                  108
+                );
+                $fmt__0 = $fmt__6;
+                $ign_flag__0 = 0;
+                $continue_label = "switch";break;
+              // FALLTHROUGH
+              case 6:
+                $fmt__7 = $fmt__0[4];
+                $prec__1 = $fmt__0[3];
+                $pad__3 = $fmt__0[2];
+                $iconv__1 = $fmt__0[1];
+                $bprint_altint_fmt(
+                  $buf,
+                  $ign_flag__0,
+                  $iconv__1,
+                  $pad__3,
+                  $prec__1,
+                  110
+                );
+                $fmt__0 = $fmt__7;
+                $ign_flag__0 = 0;
+                $continue_label = "switch";break;
+              // FALLTHROUGH
+              case 7:
+                $fmt__8 = $fmt__0[4];
+                $prec__2 = $fmt__0[3];
+                $pad__4 = $fmt__0[2];
+                $iconv__2 = $fmt__0[1];
+                $bprint_altint_fmt(
+                  $buf,
+                  $ign_flag__0,
+                  $iconv__2,
+                  $pad__4,
+                  $prec__2,
+                  76
+                );
+                $fmt__0 = $fmt__8;
+                $ign_flag__0 = 0;
+                $continue_label = "switch";break;
+              // FALLTHROUGH
+              case 8:
+                $fmt__9 = $fmt__0[4];
+                $prec__3 = $fmt__0[3];
+                $pad__5 = $fmt__0[2];
+                $fconv = $fmt__0[1];
+                $bprint_float_fmt(
+                  $buf,
+                  $ign_flag__0,
+                  $fconv,
+                  $pad__5,
+                  $prec__3
+                );
+                $fmt__0 = $fmt__9;
+                $ign_flag__0 = 0;
+                $continue_label = "switch";break;
+              // FALLTHROUGH
+              case 9:
+                $fmt__10 = $fmt__0[2];
+                $pad__6 = $fmt__0[1];
+                $buffer_add_char($buf, 37);
+                $bprint_ignored_flag($buf, $ign_flag__0);
+                $bprint_padding($buf, $pad__6);
+                $buffer_add_char($buf, 66);
+                $fmt__0 = $fmt__10;
+                $ign_flag__0 = 0;
+                $continue_label = "switch";break;
+              // FALLTHROUGH
+              case 10:
+                $fmt__11 = $fmt__0[1];
+                $buffer_add_string($buf, $cst__14);
+                $fmt__0 = $fmt__11;
+                $continue_label = "switch";break;
+              // FALLTHROUGH
+              case 11:
+                $fmt__12 = $fmt__0[2];
+                $str = $fmt__0[1];
+                $bprint_string_literal($buf, $str);
+                $fmt__0 = $fmt__12;
+                $continue_label = "switch";break;
+              // FALLTHROUGH
+              case 12:
+                $fmt__13 = $fmt__0[2];
+                $chr = $fmt__0[1];
+                $bprint_char_literal($buf, $chr);
+                $fmt__0 = $fmt__13;
+                $continue_label = "switch";break;
+              // FALLTHROUGH
+              case 13:
+                $fmt__14 = $fmt__0[3];
+                $fmtty = $fmt__0[2];
+                $pad_opt = $fmt__0[1];
+                $buffer_add_char($buf, 37);
+                $bprint_ignored_flag($buf, $ign_flag__0);
+                $bprint_pad_opt($buf, $pad_opt);
+                $buffer_add_char($buf, 123);
+                $bprint_fmtty->contents($buf, $fmtty);
+                $buffer_add_char($buf, 37);
+                $buffer_add_char($buf, 125);
+                $fmt__0 = $fmt__14;
+                $ign_flag__0 = 0;
+                $continue_label = "switch";break;
+              // FALLTHROUGH
+              case 14:
+                $fmt__15 = $fmt__0[3];
+                $fmtty__0 = $fmt__0[2];
+                $pad_opt__0 = $fmt__0[1];
+                $buffer_add_char($buf, 37);
+                $bprint_ignored_flag($buf, $ign_flag__0);
+                $bprint_pad_opt($buf, $pad_opt__0);
+                $buffer_add_char($buf, 40);
+                $bprint_fmtty->contents($buf, $fmtty__0);
+                $buffer_add_char($buf, 37);
+                $buffer_add_char($buf, 41);
+                $fmt__0 = $fmt__15;
+                $ign_flag__0 = 0;
+                $continue_label = "switch";break;
+              // FALLTHROUGH
+              case 15:
+                $fmt__16 = $fmt__0[1];
+                $buffer_add_char($buf, 37);
+                $bprint_ignored_flag($buf, $ign_flag__0);
+                $buffer_add_char($buf, 97);
+                $fmt__0 = $fmt__16;
+                $ign_flag__0 = 0;
+                $continue_label = "switch";break;
+              // FALLTHROUGH
+              case 16:
+                $fmt__17 = $fmt__0[1];
+                $buffer_add_char($buf, 37);
+                $bprint_ignored_flag($buf, $ign_flag__0);
+                $buffer_add_char($buf, 116);
+                $fmt__0 = $fmt__17;
+                $ign_flag__0 = 0;
+                $continue_label = "switch";break;
+              // FALLTHROUGH
+              case 17:
+                $fmt__18 = $fmt__0[2];
+                $fmting_lit = $fmt__0[1];
+                $bprint_string_literal(
+                  $buf,
+                  $string_of_formatting_lit($fmting_lit)
+                );
+                $fmt__0 = $fmt__18;
+                $continue_label = "switch";break;
+              // FALLTHROUGH
+              case 18:
+                $fmt__19 = $fmt__0[2];
+                $fmting_gen = $fmt__0[1];
+                $bprint_string_literal($buf, $cst__15);
+                $bprint_string_literal(
+                  $buf,
+                  $string_of_formatting_gen($fmting_gen)
+                );
+                $fmt__0 = $fmt__19;
+                $continue_label = "switch";break;
+              // FALLTHROUGH
+              case 19:
+                $fmt__20 = $fmt__0[1];
+                $buffer_add_char($buf, 37);
+                $bprint_ignored_flag($buf, $ign_flag__0);
+                $buffer_add_char($buf, 114);
+                $fmt__0 = $fmt__20;
+                $ign_flag__0 = 0;
+                $continue_label = "switch";break;
+              // FALLTHROUGH
+              case 20:
+                $fmt__21 = $fmt__0[3];
+                $char_set = $fmt__0[2];
+                $width_opt = $fmt__0[1];
+                $buffer_add_char($buf, 37);
+                $bprint_ignored_flag($buf, $ign_flag__0);
+                $bprint_pad_opt($buf, $width_opt);
+                $bprint_char_set($buf, $char_set);
+                $fmt__0 = $fmt__21;
+                $ign_flag__0 = 0;
+                $continue_label = "switch";break;
+              // FALLTHROUGH
+              case 21:
+                $fmt__22 = $fmt__0[2];
+                $counter = $fmt__0[1];
+                $buffer_add_char($buf, 37);
+                $bprint_ignored_flag($buf, $ign_flag__0);
+                $buffer_add_char($buf, $char_of_counter($counter));
+                $fmt__0 = $fmt__22;
+                $ign_flag__0 = 0;
+                $continue_label = "switch";break;
+              // FALLTHROUGH
+              case 22:
+                $fmt__23 = $fmt__0[1];
+                $buffer_add_char($buf, 37);
+                $bprint_ignored_flag($buf, $ign_flag__0);
+                $bprint_string_literal($buf, $cst_0c);
+                $fmt__0 = $fmt__23;
+                $ign_flag__0 = 0;
+                $continue_label = "switch";break;
+              // FALLTHROUGH
+              case 23:
+                $rest = $fmt__0[2];
+                $ign = $fmt__0[1];
+                $match = $param_format_of_ignored_format($ign, $rest);
+                $fmt__24 = $match[1];
+                $fmt__0 = $fmt__24;
+                $ign_flag__0 = 1;
+                $continue_label = "switch";break;
+              // FALLTHROUGH
+              default:
+                $rest__0 = $fmt__0[3];
+                $arity = $fmt__0[1];
+                $ep = $int_of_custom_arity->contents($arity);
+                $eo = 1;
+                if (! ($ep < 1)) {
+                  $i = $eo;
+                  for (;;) {
+                    $buffer_add_char($buf, 37);
+                    $bprint_ignored_flag($buf, $ign_flag__0);
+                    $buffer_add_char($buf, 63);
+                    $eq = (int) ($i + 1);
+                    if ($ep !== $i) {$i = $eq;continue;}
+                    break;
+                  }
+                }
+                $fmt__0 = $rest__0;
+                $ign_flag__0 = 0;
+                $continue_label = "switch";break;
               }
-            }
-            $fmt__0 = $rest__0;
-            $ign_flag__0 = 0;
-            continue;
+            if ($continue_label === "switch") {continue;}
           }
         }
       };
@@ -2848,173 +2862,190 @@ final class CamlinternalFormat {
     };
     $fmtty_of_fmt__0 = function(dynamic $counter, dynamic $fmtty) use ($CamlinternalFormatBasics,$call2,$caml_trampoline_return,$fmtty_of_custom,$fmtty_of_fmt,$fmtty_of_formatting_gen,$fmtty_of_ignored_format,$fmtty_of_padding_fmtty,$fmtty_of_precision_fmtty,$is_int) {
       $fmtty__0 = $fmtty;
-      for (;;) if (
-        $is_int($fmtty__0)
-      ) {return 0;}
-      else {
-        if ($fmtty__0[0] === 0) {
-          $rest = $fmtty__0[1];
-          return Vector{0, $fmtty_of_fmt->contents($rest)};
-        }
-        else if ($fmtty__0[0] === 1) {
-          $rest__0 = $fmtty__0[1];
-          return Vector{0, $fmtty_of_fmt->contents($rest__0)};
-        }
-        else if ($fmtty__0[0] === 2) {
-          $rest__1 = $fmtty__0[2];
-          $pad = $fmtty__0[1];
-          return $fmtty_of_padding_fmtty(
-            $pad,
-            Vector{1, $fmtty_of_fmt->contents($rest__1)}
-          );
-        }
-        else if ($fmtty__0[0] === 3) {
-          $rest__2 = $fmtty__0[2];
-          $pad__0 = $fmtty__0[1];
-          return $fmtty_of_padding_fmtty(
-            $pad__0,
-            Vector{1, $fmtty_of_fmt->contents($rest__2)}
-          );
-        }
-        else if ($fmtty__0[0] === 4) {
-          $rest__3 = $fmtty__0[4];
-          $prec = $fmtty__0[3];
-          $pad__1 = $fmtty__0[2];
-          $ty_rest = $fmtty_of_fmt->contents($rest__3);
-          $prec_ty = $fmtty_of_precision_fmtty->contents(
-            $prec,
-            Vector{2, $ty_rest}
-          );
-          return $fmtty_of_padding_fmtty($pad__1, $prec_ty);
-        }
-        else if ($fmtty__0[0] === 5) {
-          $rest__4 = $fmtty__0[4];
-          $prec__0 = $fmtty__0[3];
-          $pad__2 = $fmtty__0[2];
-          $ty_rest__0 = $fmtty_of_fmt->contents($rest__4);
-          $prec_ty__0 = $fmtty_of_precision_fmtty->contents(
-            $prec__0,
-            Vector{3, $ty_rest__0}
-          );
-          return $fmtty_of_padding_fmtty($pad__2, $prec_ty__0);
-        }
-        else if ($fmtty__0[0] === 6) {
-          $rest__5 = $fmtty__0[4];
-          $prec__1 = $fmtty__0[3];
-          $pad__3 = $fmtty__0[2];
-          $ty_rest__1 = $fmtty_of_fmt->contents($rest__5);
-          $prec_ty__1 = $fmtty_of_precision_fmtty->contents(
-            $prec__1,
-            Vector{4, $ty_rest__1}
-          );
-          return $fmtty_of_padding_fmtty($pad__3, $prec_ty__1);
-        }
-        else if ($fmtty__0[0] === 7) {
-          $rest__6 = $fmtty__0[4];
-          $prec__2 = $fmtty__0[3];
-          $pad__4 = $fmtty__0[2];
-          $ty_rest__2 = $fmtty_of_fmt->contents($rest__6);
-          $prec_ty__2 = $fmtty_of_precision_fmtty->contents(
-            $prec__2,
-            Vector{5, $ty_rest__2}
-          );
-          return $fmtty_of_padding_fmtty($pad__4, $prec_ty__2);
-        }
-        else if ($fmtty__0[0] === 8) {
-          $rest__7 = $fmtty__0[4];
-          $prec__3 = $fmtty__0[3];
-          $pad__5 = $fmtty__0[2];
-          $ty_rest__3 = $fmtty_of_fmt->contents($rest__7);
-          $prec_ty__3 = $fmtty_of_precision_fmtty->contents(
-            $prec__3,
-            Vector{6, $ty_rest__3}
-          );
-          return $fmtty_of_padding_fmtty($pad__5, $prec_ty__3);
-        }
-        else if ($fmtty__0[0] === 9) {
-          $rest__8 = $fmtty__0[2];
-          $pad__6 = $fmtty__0[1];
-          return $fmtty_of_padding_fmtty(
-            $pad__6,
-            Vector{7, $fmtty_of_fmt->contents($rest__8)}
-          );
-        }
-        else if ($fmtty__0[0] === 10) {
-          $fmtty__1 = $fmtty__0[1];$fmtty__0 = $fmtty__1;continue;
-        }
-        else if ($fmtty__0[0] === 11) {
-          $fmtty__2 = $fmtty__0[2];$fmtty__0 = $fmtty__2;continue;
-        }
-        else if ($fmtty__0[0] === 12) {
-          $fmtty__3 = $fmtty__0[2];$fmtty__0 = $fmtty__3;continue;
-        }
-        else if ($fmtty__0[0] === 13) {
-          $rest__9 = $fmtty__0[3];
-          $ty = $fmtty__0[2];
-          return Vector{8, $ty, $fmtty_of_fmt->contents($rest__9)};
-        }
-        else if ($fmtty__0[0] === 14) {
-          $rest__10 = $fmtty__0[3];
-          $ty__0 = $fmtty__0[2];
-          return Vector{9, $ty__0, $ty__0, $fmtty_of_fmt->contents($rest__10)};
-        }
-        else if ($fmtty__0[0] === 15) {
-          $rest__11 = $fmtty__0[1];
-          return Vector{10, $fmtty_of_fmt->contents($rest__11)};
-        }
-        else if ($fmtty__0[0] === 16) {
-          $rest__12 = $fmtty__0[1];
-          return Vector{11, $fmtty_of_fmt->contents($rest__12)};
-        }
-        else if ($fmtty__0[0] === 17) {
-          $fmtty__4 = $fmtty__0[2];$fmtty__0 = $fmtty__4;continue;
-        }
-        else if ($fmtty__0[0] === 18) {
-          $rest__13 = $fmtty__0[2];
-          $fmting_gen = $fmtty__0[1];
-          $dG = $fmtty_of_fmt->contents($rest__13);
-          $dH = $fmtty_of_formatting_gen->contents($fmting_gen);
-          return $call2($CamlinternalFormatBasics[1], $dH, $dG);
-        }
-        else if ($fmtty__0[0] === 19) {
-          $rest__14 = $fmtty__0[1];
-          return Vector{13, $fmtty_of_fmt->contents($rest__14)};
-        }
-        else if ($fmtty__0[0] === 20) {
-          $rest__15 = $fmtty__0[3];
-          return Vector{1, $fmtty_of_fmt->contents($rest__15)};
-        }
-        else if ($fmtty__0[0] === 21) {
-          $rest__16 = $fmtty__0[2];
-          return Vector{2, $fmtty_of_fmt->contents($rest__16)};
-        }
-        else if ($fmtty__0[0] === 22) {
-          $rest__17 = $fmtty__0[1];
-          return Vector{0, $fmtty_of_fmt->contents($rest__17)};
-        }
-        else if ($fmtty__0[0] === 23) {
-          $rest__18 = $fmtty__0[2];
-          $ign = $fmtty__0[1];
-          if ($counter < 50) {
-            $counter__0 = (int) ($counter + 1);
-            return $fmtty_of_ignored_format->contents(
-              $counter__0,
-              $ign,
-              $rest__18
-            );
-          }
-          return $caml_trampoline_return(
-            $fmtty_of_ignored_format->contents,
-            varray[0,$ign,$rest__18]
-          );
-        }
+      for (;;) {
+        if ($is_int($fmtty__0)) {return 0;}
         else {
-          $rest__19 = $fmtty__0[3];
-          $arity = $fmtty__0[1];
-          return $fmtty_of_custom->contents(
-            $arity,
-            $fmtty_of_fmt->contents($rest__19)
-          );
+          $continue_label = null;
+          switch($fmtty__0[0]) {
+            // FALLTHROUGH
+            case 0:
+              $rest = $fmtty__0[1];
+              return Vector{0, $fmtty_of_fmt->contents($rest)};
+            // FALLTHROUGH
+            case 1:
+              $rest__0 = $fmtty__0[1];
+              return Vector{0, $fmtty_of_fmt->contents($rest__0)};
+            // FALLTHROUGH
+            case 2:
+              $rest__1 = $fmtty__0[2];
+              $pad = $fmtty__0[1];
+              return $fmtty_of_padding_fmtty(
+                $pad,
+                Vector{1, $fmtty_of_fmt->contents($rest__1)}
+              );
+            // FALLTHROUGH
+            case 3:
+              $rest__2 = $fmtty__0[2];
+              $pad__0 = $fmtty__0[1];
+              return $fmtty_of_padding_fmtty(
+                $pad__0,
+                Vector{1, $fmtty_of_fmt->contents($rest__2)}
+              );
+            // FALLTHROUGH
+            case 4:
+              $rest__3 = $fmtty__0[4];
+              $prec = $fmtty__0[3];
+              $pad__1 = $fmtty__0[2];
+              $ty_rest = $fmtty_of_fmt->contents($rest__3);
+              $prec_ty = $fmtty_of_precision_fmtty->contents(
+                $prec,
+                Vector{2, $ty_rest}
+              );
+              return $fmtty_of_padding_fmtty($pad__1, $prec_ty);
+            // FALLTHROUGH
+            case 5:
+              $rest__4 = $fmtty__0[4];
+              $prec__0 = $fmtty__0[3];
+              $pad__2 = $fmtty__0[2];
+              $ty_rest__0 = $fmtty_of_fmt->contents($rest__4);
+              $prec_ty__0 = $fmtty_of_precision_fmtty->contents(
+                $prec__0,
+                Vector{3, $ty_rest__0}
+              );
+              return $fmtty_of_padding_fmtty($pad__2, $prec_ty__0);
+            // FALLTHROUGH
+            case 6:
+              $rest__5 = $fmtty__0[4];
+              $prec__1 = $fmtty__0[3];
+              $pad__3 = $fmtty__0[2];
+              $ty_rest__1 = $fmtty_of_fmt->contents($rest__5);
+              $prec_ty__1 = $fmtty_of_precision_fmtty->contents(
+                $prec__1,
+                Vector{4, $ty_rest__1}
+              );
+              return $fmtty_of_padding_fmtty($pad__3, $prec_ty__1);
+            // FALLTHROUGH
+            case 7:
+              $rest__6 = $fmtty__0[4];
+              $prec__2 = $fmtty__0[3];
+              $pad__4 = $fmtty__0[2];
+              $ty_rest__2 = $fmtty_of_fmt->contents($rest__6);
+              $prec_ty__2 = $fmtty_of_precision_fmtty->contents(
+                $prec__2,
+                Vector{5, $ty_rest__2}
+              );
+              return $fmtty_of_padding_fmtty($pad__4, $prec_ty__2);
+            // FALLTHROUGH
+            case 8:
+              $rest__7 = $fmtty__0[4];
+              $prec__3 = $fmtty__0[3];
+              $pad__5 = $fmtty__0[2];
+              $ty_rest__3 = $fmtty_of_fmt->contents($rest__7);
+              $prec_ty__3 = $fmtty_of_precision_fmtty->contents(
+                $prec__3,
+                Vector{6, $ty_rest__3}
+              );
+              return $fmtty_of_padding_fmtty($pad__5, $prec_ty__3);
+            // FALLTHROUGH
+            case 9:
+              $rest__8 = $fmtty__0[2];
+              $pad__6 = $fmtty__0[1];
+              return $fmtty_of_padding_fmtty(
+                $pad__6,
+                Vector{7, $fmtty_of_fmt->contents($rest__8)}
+              );
+            // FALLTHROUGH
+            case 10:
+              $fmtty__1 = $fmtty__0[1];
+              $fmtty__0 = $fmtty__1;
+              $continue_label = "switch";break;
+            // FALLTHROUGH
+            case 11:
+              $fmtty__2 = $fmtty__0[2];
+              $fmtty__0 = $fmtty__2;
+              $continue_label = "switch";break;
+            // FALLTHROUGH
+            case 12:
+              $fmtty__3 = $fmtty__0[2];
+              $fmtty__0 = $fmtty__3;
+              $continue_label = "switch";break;
+            // FALLTHROUGH
+            case 13:
+              $rest__9 = $fmtty__0[3];
+              $ty = $fmtty__0[2];
+              return Vector{8, $ty, $fmtty_of_fmt->contents($rest__9)};
+            // FALLTHROUGH
+            case 14:
+              $rest__10 = $fmtty__0[3];
+              $ty__0 = $fmtty__0[2];
+              return Vector{
+                9,
+                $ty__0,
+                $ty__0,
+                $fmtty_of_fmt->contents($rest__10)
+              };
+            // FALLTHROUGH
+            case 15:
+              $rest__11 = $fmtty__0[1];
+              return Vector{10, $fmtty_of_fmt->contents($rest__11)};
+            // FALLTHROUGH
+            case 16:
+              $rest__12 = $fmtty__0[1];
+              return Vector{11, $fmtty_of_fmt->contents($rest__12)};
+            // FALLTHROUGH
+            case 17:
+              $fmtty__4 = $fmtty__0[2];
+              $fmtty__0 = $fmtty__4;
+              $continue_label = "switch";break;
+            // FALLTHROUGH
+            case 18:
+              $rest__13 = $fmtty__0[2];
+              $fmting_gen = $fmtty__0[1];
+              $dG = $fmtty_of_fmt->contents($rest__13);
+              $dH = $fmtty_of_formatting_gen->contents($fmting_gen);
+              return $call2($CamlinternalFormatBasics[1], $dH, $dG);
+            // FALLTHROUGH
+            case 19:
+              $rest__14 = $fmtty__0[1];
+              return Vector{13, $fmtty_of_fmt->contents($rest__14)};
+            // FALLTHROUGH
+            case 20:
+              $rest__15 = $fmtty__0[3];
+              return Vector{1, $fmtty_of_fmt->contents($rest__15)};
+            // FALLTHROUGH
+            case 21:
+              $rest__16 = $fmtty__0[2];
+              return Vector{2, $fmtty_of_fmt->contents($rest__16)};
+            // FALLTHROUGH
+            case 22:
+              $rest__17 = $fmtty__0[1];
+              return Vector{0, $fmtty_of_fmt->contents($rest__17)};
+            // FALLTHROUGH
+            case 23:
+              $rest__18 = $fmtty__0[2];
+              $ign = $fmtty__0[1];
+              if ($counter < 50) {
+                $counter__0 = (int) ($counter + 1);
+                return $fmtty_of_ignored_format->contents(
+                  $counter__0,
+                  $ign,
+                  $rest__18
+                );
+              }
+              return $caml_trampoline_return(
+                $fmtty_of_ignored_format->contents,
+                varray[0,$ign,$rest__18]
+              );
+            // FALLTHROUGH
+            default:
+              $rest__19 = $fmtty__0[3];
+              $arity = $fmtty__0[1];
+              return $fmtty_of_custom->contents(
+                $arity,
+                $fmtty_of_fmt->contents($rest__19)
+              );
+            }
+          if ($continue_label === "switch") {continue;}
         }
       }
     };
@@ -4663,332 +4694,338 @@ final class CamlinternalFormat {
       $k__0 = $k;
       $acc__0 = $acc;
       $fmt__0 = $fmt;
-      for (;;) if (
-        $is_int($fmt__0)
-      ) {return $call2($k__0, $o, $acc__0);}
-      else {
-        if ($fmt__0[0] === 0) {
-          $rest = $fmt__0[1];
-          return function(dynamic $c) use ($acc__0,$k__0,$make_printf,$o,$rest) {
-            $new_acc = Vector{5, $acc__0, $c};
-            return $make_printf->contents($k__0, $o, $new_acc, $rest);
-          };
-        }
-        else if ($fmt__0[0] === 1) {
-          $rest__0 = $fmt__0[1];
-          return function(dynamic $c) use ($acc__0,$format_caml_char,$k__0,$make_printf,$o,$rest__0) {
-            $new_acc = Vector{4, $acc__0, $format_caml_char($c)};
-            return $make_printf->contents($k__0, $o, $new_acc, $rest__0);
-          };
-        }
-        else if ($fmt__0[0] === 2) {
-          $rest__1 = $fmt__0[2];
-          $pad = $fmt__0[1];
-          return $make_padding(
-            $k__0,
-            $o,
-            $acc__0,
-            $rest__1,
-            $pad,
-            function(dynamic $str) {return $str;}
-          );
-        }
-        else if ($fmt__0[0] === 3) {
-          $rest__2 = $fmt__0[2];
-          $pad__0 = $fmt__0[1];
-          return $make_padding(
-            $k__0,
-            $o,
-            $acc__0,
-            $rest__2,
-            $pad__0,
-            $string_to_caml_string
-          );
-        }
-        else if ($fmt__0[0] === 4) {
-          $rest__3 = $fmt__0[4];
-          $prec = $fmt__0[3];
-          $pad__1 = $fmt__0[2];
-          $iconv = $fmt__0[1];
-          return $make_int_padding_precision(
-            $k__0,
-            $o,
-            $acc__0,
-            $rest__3,
-            $pad__1,
-            $prec,
-            $convert_int,
-            $iconv
-          );
-        }
-        else if ($fmt__0[0] === 5) {
-          $rest__4 = $fmt__0[4];
-          $prec__0 = $fmt__0[3];
-          $pad__2 = $fmt__0[2];
-          $iconv__0 = $fmt__0[1];
-          return $make_int_padding_precision(
-            $k__0,
-            $o,
-            $acc__0,
-            $rest__4,
-            $pad__2,
-            $prec__0,
-            $convert_int32,
-            $iconv__0
-          );
-        }
-        else if ($fmt__0[0] === 6) {
-          $rest__5 = $fmt__0[4];
-          $prec__1 = $fmt__0[3];
-          $pad__3 = $fmt__0[2];
-          $iconv__1 = $fmt__0[1];
-          return $make_int_padding_precision(
-            $k__0,
-            $o,
-            $acc__0,
-            $rest__5,
-            $pad__3,
-            $prec__1,
-            $convert_nativeint,
-            $iconv__1
-          );
-        }
-        else if ($fmt__0[0] === 7) {
-          $rest__6 = $fmt__0[4];
-          $prec__2 = $fmt__0[3];
-          $pad__4 = $fmt__0[2];
-          $iconv__2 = $fmt__0[1];
-          return $make_int_padding_precision(
-            $k__0,
-            $o,
-            $acc__0,
-            $rest__6,
-            $pad__4,
-            $prec__2,
-            $convert_int64,
-            $iconv__2
-          );
-        }
-        else if ($fmt__0[0] === 8) {
-          $rest__7 = $fmt__0[4];
-          $prec__3 = $fmt__0[3];
-          $pad__5 = $fmt__0[2];
-          $fconv = $fmt__0[1];
-          return $make_float_padding_precision(
-            $k__0,
-            $o,
-            $acc__0,
-            $rest__7,
-            $pad__5,
-            $prec__3,
-            $fconv
-          );
-        }
-        else if ($fmt__0[0] === 9) {
-          $rest__8 = $fmt__0[2];
-          $pad__6 = $fmt__0[1];
-          return $make_padding(
-            $k__0,
-            $o,
-            $acc__0,
-            $rest__8,
-            $pad__6,
-            $Pervasives[18]
-          );
-        }
-        else if ($fmt__0[0] === 10) {
-          $fmt__1 = $fmt__0[1];
-          $acc__1 = Vector{7, $acc__0};
-          $acc__0 = $acc__1;
-          $fmt__0 = $fmt__1;
-          continue;
-        }
-        else if ($fmt__0[0] === 11) {
-          $fmt__2 = $fmt__0[2];
-          $str = $fmt__0[1];
-          $acc__2 = Vector{2, $acc__0, $str};
-          $acc__0 = $acc__2;
-          $fmt__0 = $fmt__2;
-          continue;
-        }
-        else if ($fmt__0[0] === 12) {
-          $fmt__3 = $fmt__0[2];
-          $chr = $fmt__0[1];
-          $acc__3 = Vector{3, $acc__0, $chr};
-          $acc__0 = $acc__3;
-          $fmt__0 = $fmt__3;
-          continue;
-        }
-        else if ($fmt__0[0] === 13) {
-          $rest__9 = $fmt__0[3];
-          $sub_fmtty = $fmt__0[2];
-          $ty = $string_of_fmtty($sub_fmtty);
-          return function(dynamic $str) use ($acc__0,$k__0,$make_printf,$o,$rest__9,$ty) {
-            return $make_printf->contents(
-              $k__0,
-              $o,
-              Vector{4, $acc__0, $ty},
-              $rest__9
-            );
-          };
-        }
-        else if ($fmt__0[0] === 14) {
-          $rest__10 = $fmt__0[3];
-          $fmtty = $fmt__0[2];
-          return function(dynamic $param) use ($CamlinternalFormatBasics,$acc__0,$call2,$fmtty,$k__0,$make_printf,$o,$recast,$rest__10) {
-            $fmt = $param[1];
-            $cW = $recast($fmt, $fmtty);
-            return $make_printf->contents(
-              $k__0,
-              $o,
-              $acc__0,
-              $call2($CamlinternalFormatBasics[3], $cW, $rest__10)
-            );
-          };
-        }
-        else if ($fmt__0[0] === 15) {
-          $rest__11 = $fmt__0[1];
-          return function(dynamic $f, dynamic $x) use ($acc__0,$call2,$k__0,$make_printf,$o,$rest__11) {
-            return $make_printf->contents(
-              $k__0,
-              $o,
-              Vector{
-                6,
-                $acc__0,
-                function(dynamic $o) use ($call2,$f,$x) {
-                  return $call2($f, $o, $x);
-                }
-              },
-              $rest__11
-            );
-          };
-        }
-        else if ($fmt__0[0] === 16) {
-          $rest__12 = $fmt__0[1];
-          return function(dynamic $f) use ($acc__0,$k__0,$make_printf,$o,$rest__12) {
-            return $make_printf->contents(
-              $k__0,
-              $o,
-              Vector{6, $acc__0, $f},
-              $rest__12
-            );
-          };
-        }
-        else if ($fmt__0[0] === 17) {
-          $fmt__4 = $fmt__0[2];
-          $fmting_lit = $fmt__0[1];
-          $acc__4 = Vector{0, $acc__0, $fmting_lit};
-          $acc__0 = $acc__4;
-          $fmt__0 = $fmt__4;
-          continue;
-        }
-        else if ($fmt__0[0] === 18) {
-          $cU = $fmt__0[1];
-          if (0 === $cU[0]) {
-            $rest__13 = $fmt__0[2];
-            $match = $cU[1];
-            $fmt__5 = $match[1];
-            $k__3 = function(dynamic $acc, dynamic $k, dynamic $rest) use ($make_printf) {
-              $k__0 = function(dynamic $koc, dynamic $kacc) use ($acc,$k,$make_printf,$rest) {
-                return $make_printf->contents(
-                  $k,
-                  $koc,
-                  Vector{1, $acc, Vector{0, $kacc}},
-                  $rest
-                );
-              };
-              return $k__0;
-            };
-            $k__1 = $k__3($acc__0, $k__0, $rest__13);
-            $k__0 = $k__1;
-            $acc__0 = 0;
-            $fmt__0 = $fmt__5;
-            continue;
-          }
-          $rest__14 = $fmt__0[2];
-          $match__0 = $cU[1];
-          $fmt__6 = $match__0[1];
-          $k__4 = function(dynamic $acc, dynamic $k, dynamic $rest) use ($make_printf) {
-            $k__0 = function(dynamic $koc, dynamic $kacc) use ($acc,$k,$make_printf,$rest) {
-              return $make_printf->contents(
-                $k,
-                $koc,
-                Vector{1, $acc, Vector{1, $kacc}},
-                $rest
-              );
-            };
-            return $k__0;
-          };
-          $k__2 = $k__4($acc__0, $k__0, $rest__14);
-          $k__0 = $k__2;
-          $acc__0 = 0;
-          $fmt__0 = $fmt__6;
-          continue;
-        }
-        else if ($fmt__0[0] === 19) {
-          throw $runtime["caml_wrap_thrown_exception"](Vector{0, $Assert_failure, $q}) as \Throwable;
-        }
-        else if ($fmt__0[0] === 20) {
-          $rest__15 = $fmt__0[3];
-          $new_acc = Vector{8, $acc__0, $cst_Printf_bad_conversion};
-          return function(dynamic $param) use ($k__0,$make_printf,$new_acc,$o,$rest__15) {
-            return $make_printf->contents($k__0, $o, $new_acc, $rest__15);
-          };
-        }
-        else if ($fmt__0[0] === 21) {
-          $rest__16 = $fmt__0[2];
-          return function(dynamic $n) use ($acc__0,$caml_format_int,$cst_u__0,$k__0,$make_printf,$o,$rest__16) {
-            $new_acc = Vector{4, $acc__0, $caml_format_int($cst_u__0, $n)};
-            return $make_printf->contents($k__0, $o, $new_acc, $rest__16);
-          };
-        }
-        else if ($fmt__0[0] === 22) {
-          $rest__17 = $fmt__0[1];
-          return function(dynamic $c) use ($acc__0,$k__0,$make_printf,$o,$rest__17) {
-            $new_acc = Vector{5, $acc__0, $c};
-            return $make_printf->contents($k__0, $o, $new_acc, $rest__17);
-          };
-        }
-        else if ($fmt__0[0] === 23) {
-          $rest__18 = $fmt__0[2];
-          $ign = $fmt__0[1];
-          if ($counter < 50) {
-            $counter__1 = (int) ($counter + 1);
-            return $make_ignored_param__0->contents(
-              $counter__1,
-              $k__0,
-              $o,
-              $acc__0,
-              $ign,
-              $rest__18
-            );
-          }
-          return $caml_trampoline_return(
-            $make_ignored_param__0->contents,
-            varray[0,$k__0,$o,$acc__0,$ign,$rest__18]
-          );
+      for (;;) {
+        if ($is_int($fmt__0)) {
+          return $call2($k__0, $o, $acc__0);
         }
         else {
-          $rest__19 = $fmt__0[3];
-          $f = $fmt__0[2];
-          $arity = $fmt__0[1];
-          $cV = $call1($f, 0);
-          if ($counter < 50) {
-            $counter__0 = (int) ($counter + 1);
-            return $make_custom__0->contents(
-              $counter__0,
-              $k__0,
-              $o,
-              $acc__0,
-              $rest__19,
-              $arity,
-              $cV
-            );
-          }
-          return $caml_trampoline_return(
-            $make_custom__0->contents,
-            varray[0,$k__0,$o,$acc__0,$rest__19,$arity,$cV]
-          );
+          $continue_label = null;
+          switch($fmt__0[0]) {
+            // FALLTHROUGH
+            case 0:
+              $rest = $fmt__0[1];
+              return function(dynamic $c) use ($acc__0,$k__0,$make_printf,$o,$rest) {
+                $new_acc = Vector{5, $acc__0, $c};
+                return $make_printf->contents($k__0, $o, $new_acc, $rest);
+              };
+            // FALLTHROUGH
+            case 1:
+              $rest__0 = $fmt__0[1];
+              return function(dynamic $c) use ($acc__0,$format_caml_char,$k__0,$make_printf,$o,$rest__0) {
+                $new_acc = Vector{4, $acc__0, $format_caml_char($c)};
+                return $make_printf->contents($k__0, $o, $new_acc, $rest__0);
+              };
+            // FALLTHROUGH
+            case 2:
+              $rest__1 = $fmt__0[2];
+              $pad = $fmt__0[1];
+              return $make_padding(
+                $k__0,
+                $o,
+                $acc__0,
+                $rest__1,
+                $pad,
+                function(dynamic $str) {return $str;}
+              );
+            // FALLTHROUGH
+            case 3:
+              $rest__2 = $fmt__0[2];
+              $pad__0 = $fmt__0[1];
+              return $make_padding(
+                $k__0,
+                $o,
+                $acc__0,
+                $rest__2,
+                $pad__0,
+                $string_to_caml_string
+              );
+            // FALLTHROUGH
+            case 4:
+              $rest__3 = $fmt__0[4];
+              $prec = $fmt__0[3];
+              $pad__1 = $fmt__0[2];
+              $iconv = $fmt__0[1];
+              return $make_int_padding_precision(
+                $k__0,
+                $o,
+                $acc__0,
+                $rest__3,
+                $pad__1,
+                $prec,
+                $convert_int,
+                $iconv
+              );
+            // FALLTHROUGH
+            case 5:
+              $rest__4 = $fmt__0[4];
+              $prec__0 = $fmt__0[3];
+              $pad__2 = $fmt__0[2];
+              $iconv__0 = $fmt__0[1];
+              return $make_int_padding_precision(
+                $k__0,
+                $o,
+                $acc__0,
+                $rest__4,
+                $pad__2,
+                $prec__0,
+                $convert_int32,
+                $iconv__0
+              );
+            // FALLTHROUGH
+            case 6:
+              $rest__5 = $fmt__0[4];
+              $prec__1 = $fmt__0[3];
+              $pad__3 = $fmt__0[2];
+              $iconv__1 = $fmt__0[1];
+              return $make_int_padding_precision(
+                $k__0,
+                $o,
+                $acc__0,
+                $rest__5,
+                $pad__3,
+                $prec__1,
+                $convert_nativeint,
+                $iconv__1
+              );
+            // FALLTHROUGH
+            case 7:
+              $rest__6 = $fmt__0[4];
+              $prec__2 = $fmt__0[3];
+              $pad__4 = $fmt__0[2];
+              $iconv__2 = $fmt__0[1];
+              return $make_int_padding_precision(
+                $k__0,
+                $o,
+                $acc__0,
+                $rest__6,
+                $pad__4,
+                $prec__2,
+                $convert_int64,
+                $iconv__2
+              );
+            // FALLTHROUGH
+            case 8:
+              $rest__7 = $fmt__0[4];
+              $prec__3 = $fmt__0[3];
+              $pad__5 = $fmt__0[2];
+              $fconv = $fmt__0[1];
+              return $make_float_padding_precision(
+                $k__0,
+                $o,
+                $acc__0,
+                $rest__7,
+                $pad__5,
+                $prec__3,
+                $fconv
+              );
+            // FALLTHROUGH
+            case 9:
+              $rest__8 = $fmt__0[2];
+              $pad__6 = $fmt__0[1];
+              return $make_padding(
+                $k__0,
+                $o,
+                $acc__0,
+                $rest__8,
+                $pad__6,
+                $Pervasives[18]
+              );
+            // FALLTHROUGH
+            case 10:
+              $fmt__1 = $fmt__0[1];
+              $acc__1 = Vector{7, $acc__0};
+              $acc__0 = $acc__1;
+              $fmt__0 = $fmt__1;
+              $continue_label = "switch";break;
+            // FALLTHROUGH
+            case 11:
+              $fmt__2 = $fmt__0[2];
+              $str = $fmt__0[1];
+              $acc__2 = Vector{2, $acc__0, $str};
+              $acc__0 = $acc__2;
+              $fmt__0 = $fmt__2;
+              $continue_label = "switch";break;
+            // FALLTHROUGH
+            case 12:
+              $fmt__3 = $fmt__0[2];
+              $chr = $fmt__0[1];
+              $acc__3 = Vector{3, $acc__0, $chr};
+              $acc__0 = $acc__3;
+              $fmt__0 = $fmt__3;
+              $continue_label = "switch";break;
+            // FALLTHROUGH
+            case 13:
+              $rest__9 = $fmt__0[3];
+              $sub_fmtty = $fmt__0[2];
+              $ty = $string_of_fmtty($sub_fmtty);
+              return function(dynamic $str) use ($acc__0,$k__0,$make_printf,$o,$rest__9,$ty) {
+                return $make_printf->contents(
+                  $k__0,
+                  $o,
+                  Vector{4, $acc__0, $ty},
+                  $rest__9
+                );
+              };
+            // FALLTHROUGH
+            case 14:
+              $rest__10 = $fmt__0[3];
+              $fmtty = $fmt__0[2];
+              return function(dynamic $param) use ($CamlinternalFormatBasics,$acc__0,$call2,$fmtty,$k__0,$make_printf,$o,$recast,$rest__10) {
+                $fmt = $param[1];
+                $cW = $recast($fmt, $fmtty);
+                return $make_printf->contents(
+                  $k__0,
+                  $o,
+                  $acc__0,
+                  $call2($CamlinternalFormatBasics[3], $cW, $rest__10)
+                );
+              };
+            // FALLTHROUGH
+            case 15:
+              $rest__11 = $fmt__0[1];
+              return function(dynamic $f, dynamic $x) use ($acc__0,$call2,$k__0,$make_printf,$o,$rest__11) {
+                return $make_printf->contents(
+                  $k__0,
+                  $o,
+                  Vector{
+                    6,
+                    $acc__0,
+                    function(dynamic $o) use ($call2,$f,$x) {
+                      return $call2($f, $o, $x);
+                    }
+                  },
+                  $rest__11
+                );
+              };
+            // FALLTHROUGH
+            case 16:
+              $rest__12 = $fmt__0[1];
+              return function(dynamic $f) use ($acc__0,$k__0,$make_printf,$o,$rest__12) {
+                return $make_printf->contents(
+                  $k__0,
+                  $o,
+                  Vector{6, $acc__0, $f},
+                  $rest__12
+                );
+              };
+            // FALLTHROUGH
+            case 17:
+              $fmt__4 = $fmt__0[2];
+              $fmting_lit = $fmt__0[1];
+              $acc__4 = Vector{0, $acc__0, $fmting_lit};
+              $acc__0 = $acc__4;
+              $fmt__0 = $fmt__4;
+              $continue_label = "switch";break;
+            // FALLTHROUGH
+            case 18:
+              $cU = $fmt__0[1];
+              if (0 === $cU[0]) {
+                $rest__13 = $fmt__0[2];
+                $match = $cU[1];
+                $fmt__5 = $match[1];
+                $k__3 = function(dynamic $acc, dynamic $k, dynamic $rest) use ($make_printf) {
+                  $k__0 = function(dynamic $koc, dynamic $kacc) use ($acc,$k,$make_printf,$rest) {
+                    return $make_printf->contents(
+                      $k,
+                      $koc,
+                      Vector{1, $acc, Vector{0, $kacc}},
+                      $rest
+                    );
+                  };
+                  return $k__0;
+                };
+                $k__1 = $k__3($acc__0, $k__0, $rest__13);
+                $k__0 = $k__1;
+                $acc__0 = 0;
+                $fmt__0 = $fmt__5;
+                $continue_label = "switch";break;
+              }
+              $rest__14 = $fmt__0[2];
+              $match__0 = $cU[1];
+              $fmt__6 = $match__0[1];
+              $k__4 = function(dynamic $acc, dynamic $k, dynamic $rest) use ($make_printf) {
+                $k__0 = function(dynamic $koc, dynamic $kacc) use ($acc,$k,$make_printf,$rest) {
+                  return $make_printf->contents(
+                    $k,
+                    $koc,
+                    Vector{1, $acc, Vector{1, $kacc}},
+                    $rest
+                  );
+                };
+                return $k__0;
+              };
+              $k__2 = $k__4($acc__0, $k__0, $rest__14);
+              $k__0 = $k__2;
+              $acc__0 = 0;
+              $fmt__0 = $fmt__6;
+              $continue_label = "switch";break;
+            // FALLTHROUGH
+            case 19:
+              throw $runtime["caml_wrap_thrown_exception"](Vector{0, $Assert_failure, $q}) as \Throwable;
+            // FALLTHROUGH
+            case 20:
+              $rest__15 = $fmt__0[3];
+              $new_acc = Vector{8, $acc__0, $cst_Printf_bad_conversion};
+              return function(dynamic $param) use ($k__0,$make_printf,$new_acc,$o,$rest__15) {
+                return $make_printf->contents($k__0, $o, $new_acc, $rest__15);
+              };
+            // FALLTHROUGH
+            case 21:
+              $rest__16 = $fmt__0[2];
+              return function(dynamic $n) use ($acc__0,$caml_format_int,$cst_u__0,$k__0,$make_printf,$o,$rest__16) {
+                $new_acc = Vector{4, $acc__0, $caml_format_int($cst_u__0, $n)};
+                return $make_printf->contents($k__0, $o, $new_acc, $rest__16);
+              };
+            // FALLTHROUGH
+            case 22:
+              $rest__17 = $fmt__0[1];
+              return function(dynamic $c) use ($acc__0,$k__0,$make_printf,$o,$rest__17) {
+                $new_acc = Vector{5, $acc__0, $c};
+                return $make_printf->contents($k__0, $o, $new_acc, $rest__17);
+              };
+            // FALLTHROUGH
+            case 23:
+              $rest__18 = $fmt__0[2];
+              $ign = $fmt__0[1];
+              if ($counter < 50) {
+                $counter__1 = (int) ($counter + 1);
+                return $make_ignored_param__0->contents(
+                  $counter__1,
+                  $k__0,
+                  $o,
+                  $acc__0,
+                  $ign,
+                  $rest__18
+                );
+              }
+              return $caml_trampoline_return(
+                $make_ignored_param__0->contents,
+                varray[0,$k__0,$o,$acc__0,$ign,$rest__18]
+              );
+            // FALLTHROUGH
+            default:
+              $rest__19 = $fmt__0[3];
+              $f = $fmt__0[2];
+              $arity = $fmt__0[1];
+              $cV = $call1($f, 0);
+              if ($counter < 50) {
+                $counter__0 = (int) ($counter + 1);
+                return $make_custom__0->contents(
+                  $counter__0,
+                  $k__0,
+                  $o,
+                  $acc__0,
+                  $rest__19,
+                  $arity,
+                  $cV
+                );
+              }
+              return $caml_trampoline_return(
+                $make_custom__0->contents,
+                varray[0,$k__0,$o,$acc__0,$rest__19,$arity,$cV]
+              );
+            }
+          if ($continue_label === "switch") {continue;}
         }
       }
     };
@@ -5495,294 +5532,309 @@ final class CamlinternalFormat {
     (dynamic $counter, dynamic $k, dynamic $o, dynamic $fmt) use ($Assert_failure,$CamlinternalFormatBasics,$call1,$call2,$caml_trampoline_return,$const__0,$fn_of_custom_arity__0,$fn_of_padding_precision,$is_int,$make_ignored_param,$make_iprintf,$recast,$runtime,$u) {
       $k__0 = $k;
       $fmt__0 = $fmt;
-      for (;;) if (
-        $is_int($fmt__0)
-      ) {return $call1($k__0, $o);}
-      else {
-        if ($fmt__0[0] === 0) {
-          $rest = $fmt__0[1];
-          $bC = $make_iprintf->contents($k__0, $o, $rest);
-          return function(dynamic $cm) use ($bC,$const__0) {
-            return $const__0($bC, $cm);
-          };
-        }
-        else if ($fmt__0[0] === 1) {
-          $rest__0 = $fmt__0[1];
-          $bD = $make_iprintf->contents($k__0, $o, $rest__0);
-          return function(dynamic $cl) use ($bD,$const__0) {
-            return $const__0($bD, $cl);
-          };
-        }
-        else if ($fmt__0[0] === 2) {
-          $bE = $fmt__0[1];
-          if ($is_int($bE)) {
-            $rest__1 = $fmt__0[2];
-            $bF = $make_iprintf->contents($k__0, $o, $rest__1);
-            return function(dynamic $ch) use ($bF,$const__0) {
-              return $const__0($bF, $ch);
-            };
-          }
-          else {
-            if (0 === $bE[0]) {
-              $rest__2 = $fmt__0[2];
-              $bG = $make_iprintf->contents($k__0, $o, $rest__2);
-              return function(dynamic $ck) use ($bG,$const__0) {
-                return $const__0($bG, $ck);
-              };
-            }
-            $rest__3 = $fmt__0[2];
-            $bH = $make_iprintf->contents($k__0, $o, $rest__3);
-            $bI = function(dynamic $cj) use ($bH,$const__0) {
-              return $const__0($bH, $cj);
-            };
-            return function(dynamic $ci) use ($bI,$const__0) {
-              return $const__0($bI, $ci);
-            };
-          }
-        }
-        else if ($fmt__0[0] === 3) {
-          $bJ = $fmt__0[1];
-          if ($is_int($bJ)) {
-            $rest__4 = $fmt__0[2];
-            $bK = $make_iprintf->contents($k__0, $o, $rest__4);
-            return function(dynamic $cd) use ($bK,$const__0) {
-              return $const__0($bK, $cd);
-            };
-          }
-          else {
-            if (0 === $bJ[0]) {
-              $rest__5 = $fmt__0[2];
-              $bL = $make_iprintf->contents($k__0, $o, $rest__5);
-              return function(dynamic $cg) use ($bL,$const__0) {
-                return $const__0($bL, $cg);
-              };
-            }
-            $rest__6 = $fmt__0[2];
-            $bM = $make_iprintf->contents($k__0, $o, $rest__6);
-            $bN = function(dynamic $cf) use ($bM,$const__0) {
-              return $const__0($bM, $cf);
-            };
-            return function(dynamic $ce) use ($bN,$const__0) {
-              return $const__0($bN, $ce);
-            };
-          }
-        }
-        else if ($fmt__0[0] === 4) {
-          $rest__7 = $fmt__0[4];
-          $prec = $fmt__0[3];
-          $pad = $fmt__0[2];
-          return $fn_of_padding_precision($k__0, $o, $rest__7, $pad, $prec);
-        }
-        else if ($fmt__0[0] === 5) {
-          $rest__8 = $fmt__0[4];
-          $prec__0 = $fmt__0[3];
-          $pad__0 = $fmt__0[2];
-          return $fn_of_padding_precision(
-            $k__0,
-            $o,
-            $rest__8,
-            $pad__0,
-            $prec__0
-          );
-        }
-        else if ($fmt__0[0] === 6) {
-          $rest__9 = $fmt__0[4];
-          $prec__1 = $fmt__0[3];
-          $pad__1 = $fmt__0[2];
-          return $fn_of_padding_precision(
-            $k__0,
-            $o,
-            $rest__9,
-            $pad__1,
-            $prec__1
-          );
-        }
-        else if ($fmt__0[0] === 7) {
-          $rest__10 = $fmt__0[4];
-          $prec__2 = $fmt__0[3];
-          $pad__2 = $fmt__0[2];
-          return $fn_of_padding_precision(
-            $k__0,
-            $o,
-            $rest__10,
-            $pad__2,
-            $prec__2
-          );
-        }
-        else if ($fmt__0[0] === 8) {
-          $rest__11 = $fmt__0[4];
-          $prec__3 = $fmt__0[3];
-          $pad__3 = $fmt__0[2];
-          return $fn_of_padding_precision(
-            $k__0,
-            $o,
-            $rest__11,
-            $pad__3,
-            $prec__3
-          );
-        }
-        else if ($fmt__0[0] === 9) {
-          $bO = $fmt__0[1];
-          if ($is_int($bO)) {
-            $rest__12 = $fmt__0[2];
-            $bP = $make_iprintf->contents($k__0, $o, $rest__12);
-            return function(dynamic $b_) use ($bP,$const__0) {
-              return $const__0($bP, $b_);
-            };
-          }
-          else {
-            if (0 === $bO[0]) {
-              $rest__13 = $fmt__0[2];
-              $bQ = $make_iprintf->contents($k__0, $o, $rest__13);
-              return function(dynamic $cc) use ($bQ,$const__0) {
-                return $const__0($bQ, $cc);
-              };
-            }
-            $rest__14 = $fmt__0[2];
-            $bR = $make_iprintf->contents($k__0, $o, $rest__14);
-            $bS = function(dynamic $cb) use ($bR,$const__0) {
-              return $const__0($bR, $cb);
-            };
-            return function(dynamic $ca) use ($bS,$const__0) {
-              return $const__0($bS, $ca);
-            };
-          }
-        }
-        else if ($fmt__0[0] === 10) {
-          $fmt__1 = $fmt__0[1];$fmt__0 = $fmt__1;continue;
-        }
-        else if ($fmt__0[0] === 11) {
-          $fmt__2 = $fmt__0[2];$fmt__0 = $fmt__2;continue;
-        }
-        else if ($fmt__0[0] === 12) {
-          $fmt__3 = $fmt__0[2];$fmt__0 = $fmt__3;continue;
-        }
-        else if ($fmt__0[0] === 13) {
-          $rest__15 = $fmt__0[3];
-          $bT = $make_iprintf->contents($k__0, $o, $rest__15);
-          return function(dynamic $b9) use ($bT,$const__0) {
-            return $const__0($bT, $b9);
-          };
-        }
-        else if ($fmt__0[0] === 14) {
-          $rest__16 = $fmt__0[3];
-          $fmtty = $fmt__0[2];
-          return function(dynamic $param) use ($CamlinternalFormatBasics,$call2,$fmtty,$k__0,$make_iprintf,$o,$recast,$rest__16) {
-            $fmt = $param[1];
-            $b8 = $recast($fmt, $fmtty);
-            return $make_iprintf->contents(
-              $k__0,
-              $o,
-              $call2($CamlinternalFormatBasics[3], $b8, $rest__16)
-            );
-          };
-        }
-        else if ($fmt__0[0] === 15) {
-          $rest__17 = $fmt__0[1];
-          $bU = $make_iprintf->contents($k__0, $o, $rest__17);
-          $bV = function(dynamic $b7) use ($bU,$const__0) {
-            return $const__0($bU, $b7);
-          };
-          return function(dynamic $b6) use ($bV,$const__0) {
-            return $const__0($bV, $b6);
-          };
-        }
-        else if ($fmt__0[0] === 16) {
-          $rest__18 = $fmt__0[1];
-          $bW = $make_iprintf->contents($k__0, $o, $rest__18);
-          return function(dynamic $b5) use ($bW,$const__0) {
-            return $const__0($bW, $b5);
-          };
-        }
-        else if ($fmt__0[0] === 17) {
-          $fmt__4 = $fmt__0[2];$fmt__0 = $fmt__4;continue;
-        }
-        else if ($fmt__0[0] === 18) {
-          $bX = $fmt__0[1];
-          if (0 === $bX[0]) {
-            $rest__19 = $fmt__0[2];
-            $match = $bX[1];
-            $fmt__5 = $match[1];
-            $k__3 = function(dynamic $k, dynamic $rest) use ($make_iprintf) {
-              $k__0 = function(dynamic $koc) use ($k,$make_iprintf,$rest) {
-                return $make_iprintf->contents($k, $koc, $rest);
-              };
-              return $k__0;
-            };
-            $k__1 = $k__3($k__0, $rest__19);
-            $k__0 = $k__1;
-            $fmt__0 = $fmt__5;
-            continue;
-          }
-          $rest__20 = $fmt__0[2];
-          $match__0 = $bX[1];
-          $fmt__6 = $match__0[1];
-          $k__4 = function(dynamic $k, dynamic $rest) use ($make_iprintf) {
-            $k__0 = function(dynamic $koc) use ($k,$make_iprintf,$rest) {
-              return $make_iprintf->contents($k, $koc, $rest);
-            };
-            return $k__0;
-          };
-          $k__2 = $k__4($k__0, $rest__20);
-          $k__0 = $k__2;
-          $fmt__0 = $fmt__6;
-          continue;
-        }
-        else if ($fmt__0[0] === 19) {
-          throw $runtime["caml_wrap_thrown_exception"](Vector{0, $Assert_failure, $u}) as \Throwable;
-        }
-        else if ($fmt__0[0] === 20) {
-          $rest__21 = $fmt__0[3];
-          $bY = $make_iprintf->contents($k__0, $o, $rest__21);
-          return function(dynamic $b4) use ($bY,$const__0) {
-            return $const__0($bY, $b4);
-          };
-        }
-        else if ($fmt__0[0] === 21) {
-          $rest__22 = $fmt__0[2];
-          $bZ = $make_iprintf->contents($k__0, $o, $rest__22);
-          return function(dynamic $b3) use ($bZ,$const__0) {
-            return $const__0($bZ, $b3);
-          };
-        }
-        else if ($fmt__0[0] === 22) {
-          $rest__23 = $fmt__0[1];
-          $b0 = $make_iprintf->contents($k__0, $o, $rest__23);
-          return function(dynamic $b2) use ($b0,$const__0) {
-            return $const__0($b0, $b2);
-          };
-        }
-        else if ($fmt__0[0] === 23) {
-          $rest__24 = $fmt__0[2];
-          $ign = $fmt__0[1];
-          $b1 = 0;
-          return $make_ignored_param(
-            function(dynamic $x, dynamic $param) use ($call1,$k__0) {
-              return $call1($k__0, $x);
-            },
-            $o,
-            $b1,
-            $ign,
-            $rest__24
-          );
+      for (;;) {
+        if ($is_int($fmt__0)) {
+          return $call1($k__0, $o);
         }
         else {
-          $rest__25 = $fmt__0[3];
-          $arity = $fmt__0[1];
-          if ($counter < 50) {
-            $counter__0 = (int) ($counter + 1);
-            return $fn_of_custom_arity__0->contents(
-              $counter__0,
-              $k__0,
-              $o,
-              $rest__25,
-              $arity
-            );
-          }
-          return $caml_trampoline_return(
-            $fn_of_custom_arity__0->contents,
-            varray[0,$k__0,$o,$rest__25,$arity]
-          );
+          $continue_label = null;
+          switch($fmt__0[0]) {
+            // FALLTHROUGH
+            case 0:
+              $rest = $fmt__0[1];
+              $bC = $make_iprintf->contents($k__0, $o, $rest);
+              return function(dynamic $cm) use ($bC,$const__0) {
+                return $const__0($bC, $cm);
+              };
+            // FALLTHROUGH
+            case 1:
+              $rest__0 = $fmt__0[1];
+              $bD = $make_iprintf->contents($k__0, $o, $rest__0);
+              return function(dynamic $cl) use ($bD,$const__0) {
+                return $const__0($bD, $cl);
+              };
+            // FALLTHROUGH
+            case 2:
+              $bE = $fmt__0[1];
+              if ($is_int($bE)) {
+                $rest__1 = $fmt__0[2];
+                $bF = $make_iprintf->contents($k__0, $o, $rest__1);
+                return function(dynamic $ch) use ($bF,$const__0) {
+                  return $const__0($bF, $ch);
+                };
+              }
+              else {
+                if (0 === $bE[0]) {
+                  $rest__2 = $fmt__0[2];
+                  $bG = $make_iprintf->contents($k__0, $o, $rest__2);
+                  return function(dynamic $ck) use ($bG,$const__0) {
+                    return $const__0($bG, $ck);
+                  };
+                }
+                $rest__3 = $fmt__0[2];
+                $bH = $make_iprintf->contents($k__0, $o, $rest__3);
+                $bI = function(dynamic $cj) use ($bH,$const__0) {
+                  return $const__0($bH, $cj);
+                };
+                return function(dynamic $ci) use ($bI,$const__0) {
+                  return $const__0($bI, $ci);
+                };
+              }
+            // FALLTHROUGH
+            case 3:
+              $bJ = $fmt__0[1];
+              if ($is_int($bJ)) {
+                $rest__4 = $fmt__0[2];
+                $bK = $make_iprintf->contents($k__0, $o, $rest__4);
+                return function(dynamic $cd) use ($bK,$const__0) {
+                  return $const__0($bK, $cd);
+                };
+              }
+              else {
+                if (0 === $bJ[0]) {
+                  $rest__5 = $fmt__0[2];
+                  $bL = $make_iprintf->contents($k__0, $o, $rest__5);
+                  return function(dynamic $cg) use ($bL,$const__0) {
+                    return $const__0($bL, $cg);
+                  };
+                }
+                $rest__6 = $fmt__0[2];
+                $bM = $make_iprintf->contents($k__0, $o, $rest__6);
+                $bN = function(dynamic $cf) use ($bM,$const__0) {
+                  return $const__0($bM, $cf);
+                };
+                return function(dynamic $ce) use ($bN,$const__0) {
+                  return $const__0($bN, $ce);
+                };
+              }
+            // FALLTHROUGH
+            case 4:
+              $rest__7 = $fmt__0[4];
+              $prec = $fmt__0[3];
+              $pad = $fmt__0[2];
+              return $fn_of_padding_precision($k__0, $o, $rest__7, $pad, $prec
+              );
+            // FALLTHROUGH
+            case 5:
+              $rest__8 = $fmt__0[4];
+              $prec__0 = $fmt__0[3];
+              $pad__0 = $fmt__0[2];
+              return $fn_of_padding_precision(
+                $k__0,
+                $o,
+                $rest__8,
+                $pad__0,
+                $prec__0
+              );
+            // FALLTHROUGH
+            case 6:
+              $rest__9 = $fmt__0[4];
+              $prec__1 = $fmt__0[3];
+              $pad__1 = $fmt__0[2];
+              return $fn_of_padding_precision(
+                $k__0,
+                $o,
+                $rest__9,
+                $pad__1,
+                $prec__1
+              );
+            // FALLTHROUGH
+            case 7:
+              $rest__10 = $fmt__0[4];
+              $prec__2 = $fmt__0[3];
+              $pad__2 = $fmt__0[2];
+              return $fn_of_padding_precision(
+                $k__0,
+                $o,
+                $rest__10,
+                $pad__2,
+                $prec__2
+              );
+            // FALLTHROUGH
+            case 8:
+              $rest__11 = $fmt__0[4];
+              $prec__3 = $fmt__0[3];
+              $pad__3 = $fmt__0[2];
+              return $fn_of_padding_precision(
+                $k__0,
+                $o,
+                $rest__11,
+                $pad__3,
+                $prec__3
+              );
+            // FALLTHROUGH
+            case 9:
+              $bO = $fmt__0[1];
+              if ($is_int($bO)) {
+                $rest__12 = $fmt__0[2];
+                $bP = $make_iprintf->contents($k__0, $o, $rest__12);
+                return function(dynamic $b_) use ($bP,$const__0) {
+                  return $const__0($bP, $b_);
+                };
+              }
+              else {
+                if (0 === $bO[0]) {
+                  $rest__13 = $fmt__0[2];
+                  $bQ = $make_iprintf->contents($k__0, $o, $rest__13);
+                  return function(dynamic $cc) use ($bQ,$const__0) {
+                    return $const__0($bQ, $cc);
+                  };
+                }
+                $rest__14 = $fmt__0[2];
+                $bR = $make_iprintf->contents($k__0, $o, $rest__14);
+                $bS = function(dynamic $cb) use ($bR,$const__0) {
+                  return $const__0($bR, $cb);
+                };
+                return function(dynamic $ca) use ($bS,$const__0) {
+                  return $const__0($bS, $ca);
+                };
+              }
+            // FALLTHROUGH
+            case 10:
+              $fmt__1 = $fmt__0[1];
+              $fmt__0 = $fmt__1;
+              $continue_label = "switch";break;
+            // FALLTHROUGH
+            case 11:
+              $fmt__2 = $fmt__0[2];
+              $fmt__0 = $fmt__2;
+              $continue_label = "switch";break;
+            // FALLTHROUGH
+            case 12:
+              $fmt__3 = $fmt__0[2];
+              $fmt__0 = $fmt__3;
+              $continue_label = "switch";break;
+            // FALLTHROUGH
+            case 13:
+              $rest__15 = $fmt__0[3];
+              $bT = $make_iprintf->contents($k__0, $o, $rest__15);
+              return function(dynamic $b9) use ($bT,$const__0) {
+                return $const__0($bT, $b9);
+              };
+            // FALLTHROUGH
+            case 14:
+              $rest__16 = $fmt__0[3];
+              $fmtty = $fmt__0[2];
+              return function(dynamic $param) use ($CamlinternalFormatBasics,$call2,$fmtty,$k__0,$make_iprintf,$o,$recast,$rest__16) {
+                $fmt = $param[1];
+                $b8 = $recast($fmt, $fmtty);
+                return $make_iprintf->contents(
+                  $k__0,
+                  $o,
+                  $call2($CamlinternalFormatBasics[3], $b8, $rest__16)
+                );
+              };
+            // FALLTHROUGH
+            case 15:
+              $rest__17 = $fmt__0[1];
+              $bU = $make_iprintf->contents($k__0, $o, $rest__17);
+              $bV = function(dynamic $b7) use ($bU,$const__0) {
+                return $const__0($bU, $b7);
+              };
+              return function(dynamic $b6) use ($bV,$const__0) {
+                return $const__0($bV, $b6);
+              };
+            // FALLTHROUGH
+            case 16:
+              $rest__18 = $fmt__0[1];
+              $bW = $make_iprintf->contents($k__0, $o, $rest__18);
+              return function(dynamic $b5) use ($bW,$const__0) {
+                return $const__0($bW, $b5);
+              };
+            // FALLTHROUGH
+            case 17:
+              $fmt__4 = $fmt__0[2];
+              $fmt__0 = $fmt__4;
+              $continue_label = "switch";break;
+            // FALLTHROUGH
+            case 18:
+              $bX = $fmt__0[1];
+              if (0 === $bX[0]) {
+                $rest__19 = $fmt__0[2];
+                $match = $bX[1];
+                $fmt__5 = $match[1];
+                $k__3 = function(dynamic $k, dynamic $rest) use ($make_iprintf) {
+                  $k__0 = function(dynamic $koc) use ($k,$make_iprintf,$rest) {
+                    return $make_iprintf->contents($k, $koc, $rest);
+                  };
+                  return $k__0;
+                };
+                $k__1 = $k__3($k__0, $rest__19);
+                $k__0 = $k__1;
+                $fmt__0 = $fmt__5;
+                $continue_label = "switch";break;
+              }
+              $rest__20 = $fmt__0[2];
+              $match__0 = $bX[1];
+              $fmt__6 = $match__0[1];
+              $k__4 = function(dynamic $k, dynamic $rest) use ($make_iprintf) {
+                $k__0 = function(dynamic $koc) use ($k,$make_iprintf,$rest) {
+                  return $make_iprintf->contents($k, $koc, $rest);
+                };
+                return $k__0;
+              };
+              $k__2 = $k__4($k__0, $rest__20);
+              $k__0 = $k__2;
+              $fmt__0 = $fmt__6;
+              $continue_label = "switch";break;
+            // FALLTHROUGH
+            case 19:
+              throw $runtime["caml_wrap_thrown_exception"](Vector{0, $Assert_failure, $u}) as \Throwable;
+            // FALLTHROUGH
+            case 20:
+              $rest__21 = $fmt__0[3];
+              $bY = $make_iprintf->contents($k__0, $o, $rest__21);
+              return function(dynamic $b4) use ($bY,$const__0) {
+                return $const__0($bY, $b4);
+              };
+            // FALLTHROUGH
+            case 21:
+              $rest__22 = $fmt__0[2];
+              $bZ = $make_iprintf->contents($k__0, $o, $rest__22);
+              return function(dynamic $b3) use ($bZ,$const__0) {
+                return $const__0($bZ, $b3);
+              };
+            // FALLTHROUGH
+            case 22:
+              $rest__23 = $fmt__0[1];
+              $b0 = $make_iprintf->contents($k__0, $o, $rest__23);
+              return function(dynamic $b2) use ($b0,$const__0) {
+                return $const__0($b0, $b2);
+              };
+            // FALLTHROUGH
+            case 23:
+              $rest__24 = $fmt__0[2];
+              $ign = $fmt__0[1];
+              $b1 = 0;
+              return $make_ignored_param(
+                function(dynamic $x, dynamic $param) use ($call1,$k__0) {
+                  return $call1($k__0, $x);
+                },
+                $o,
+                $b1,
+                $ign,
+                $rest__24
+              );
+            // FALLTHROUGH
+            default:
+              $rest__25 = $fmt__0[3];
+              $arity = $fmt__0[1];
+              if ($counter < 50) {
+                $counter__0 = (int) ($counter + 1);
+                return $fn_of_custom_arity__0->contents(
+                  $counter__0,
+                  $k__0,
+                  $o,
+                  $rest__25,
+                  $arity
+                );
+              }
+              return $caml_trampoline_return(
+                $fn_of_custom_arity__0->contents,
+                varray[0,$k__0,$o,$rest__25,$arity]
+              );
+            }
+          if ($continue_label === "switch") {continue;}
         }
       }
     };
@@ -5812,181 +5864,200 @@ final class CamlinternalFormat {
     };
     $output_acc->contents = function(dynamic $o, dynamic $acc) use ($Pervasives,$call1,$call2,$cst__17,$cst__18,$is_int,$output_acc,$string_of_formatting_lit) {
       $acc__0 = $acc;
-      for (;;) if (
-        $is_int($acc__0)
-      ) {return 0;}
-      else {
-        if ($acc__0[0] === 0) {
-          $fmting_lit = $acc__0[2];
-          $p = $acc__0[1];
-          $s = $string_of_formatting_lit($fmting_lit);
-          $output_acc->contents($o, $p);
-          return $call2($Pervasives[54], $o, $s);
-        }
-        else if ($acc__0[0] === 1) {
-          $by = $acc__0[2];
-          $bz = $acc__0[1];
-          if (0 === $by[0]) {
-            $acc__1 = $by[1];
-            $output_acc->contents($o, $bz);
-            $call2($Pervasives[54], $o, $cst__17);
-            $acc__0 = $acc__1;
-            continue;
-          }
-          $acc__2 = $by[1];
-          $output_acc->contents($o, $bz);
-          $call2($Pervasives[54], $o, $cst__18);
-          $acc__0 = $acc__2;
-          continue;
-        }
-        else if ($acc__0[0] === 6) {
-          $f = $acc__0[2];
-          $p__2 = $acc__0[1];
-          $output_acc->contents($o, $p__2);
-          return $call1($f, $o);
-        }
-        else if ($acc__0[0] === 7) {
-          $p__3 = $acc__0[1];
-          $output_acc->contents($o, $p__3);
-          return $call1($Pervasives[51], $o);
-        }
-        else if ($acc__0[0] === 8) {
-          $msg = $acc__0[2];
-          $p__4 = $acc__0[1];
-          $output_acc->contents($o, $p__4);
-          return $call1($Pervasives[1], $msg);
-        }
-        else if ($acc__0[0] === 2) {}
-        else if ($acc__0[0] === 4) {
-          $s__0 = $acc__0[2];
-          $p__0 = $acc__0[1];
-          $output_acc->contents($o, $p__0);
-          return $call2($Pervasives[54], $o, $s__0);
-        }
+      for (;;) {
+        if ($is_int($acc__0)) {return 0;}
         else {
-          $c = $acc__0[2];
-          $p__1 = $acc__0[1];
-          $output_acc->contents($o, $p__1);
-          return $call2($Pervasives[53], $o, $c);
+          $continue_label = null;
+          switch($acc__0[0]) {
+            // FALLTHROUGH
+            case 0:
+              $fmting_lit = $acc__0[2];
+              $p = $acc__0[1];
+              $s = $string_of_formatting_lit($fmting_lit);
+              $output_acc->contents($o, $p);
+              return $call2($Pervasives[54], $o, $s);
+            // FALLTHROUGH
+            case 1:
+              $by = $acc__0[2];
+              $bz = $acc__0[1];
+              if (0 === $by[0]) {
+                $acc__1 = $by[1];
+                $output_acc->contents($o, $bz);
+                $call2($Pervasives[54], $o, $cst__17);
+                $acc__0 = $acc__1;
+                $continue_label = "switch";break;
+              }
+              $acc__2 = $by[1];
+              $output_acc->contents($o, $bz);
+              $call2($Pervasives[54], $o, $cst__18);
+              $acc__0 = $acc__2;
+              $continue_label = "switch";break;
+            // FALLTHROUGH
+            case 6:
+              $f = $acc__0[2];
+              $p__2 = $acc__0[1];
+              $output_acc->contents($o, $p__2);
+              return $call1($f, $o);
+            // FALLTHROUGH
+            case 7:
+              $p__3 = $acc__0[1];
+              $output_acc->contents($o, $p__3);
+              return $call1($Pervasives[51], $o);
+            // FALLTHROUGH
+            case 8:
+              $msg = $acc__0[2];
+              $p__4 = $acc__0[1];
+              $output_acc->contents($o, $p__4);
+              return $call1($Pervasives[1], $msg);
+            // FALLTHROUGH
+            case 2:
+            // FALLTHROUGH
+            case 4:
+              $s__0 = $acc__0[2];
+              $p__0 = $acc__0[1];
+              $output_acc->contents($o, $p__0);
+              return $call2($Pervasives[54], $o, $s__0);
+            // FALLTHROUGH
+            default:
+              $c = $acc__0[2];
+              $p__1 = $acc__0[1];
+              $output_acc->contents($o, $p__1);
+              return $call2($Pervasives[53], $o, $c);
+            }
+          if ($continue_label === "switch") {continue;}
         }
       }
     };
     $bufput_acc->contents = function(dynamic $b, dynamic $acc) use ($Buffer,$Pervasives,$bufput_acc,$call1,$call2,$cst__19,$cst__20,$is_int,$string_of_formatting_lit) {
       $acc__0 = $acc;
-      for (;;) if (
-        $is_int($acc__0)
-      ) {return 0;}
-      else {
-        if ($acc__0[0] === 0) {
-          $fmting_lit = $acc__0[2];
-          $p = $acc__0[1];
-          $s = $string_of_formatting_lit($fmting_lit);
-          $bufput_acc->contents($b, $p);
-          return $call2($Buffer[14], $b, $s);
-        }
-        else if ($acc__0[0] === 1) {
-          $bw = $acc__0[2];
-          $bx = $acc__0[1];
-          if (0 === $bw[0]) {
-            $acc__1 = $bw[1];
-            $bufput_acc->contents($b, $bx);
-            $call2($Buffer[14], $b, $cst__19);
-            $acc__0 = $acc__1;
-            continue;
-          }
-          $acc__2 = $bw[1];
-          $bufput_acc->contents($b, $bx);
-          $call2($Buffer[14], $b, $cst__20);
-          $acc__0 = $acc__2;
-          continue;
-        }
-        else if ($acc__0[0] === 6) {
-          $f = $acc__0[2];
-          $p__2 = $acc__0[1];
-          $bufput_acc->contents($b, $p__2);
-          return $call1($f, $b);
-        }
-        else if ($acc__0[0] === 7) {
-          $acc__3 = $acc__0[1];$acc__0 = $acc__3;continue;
-        }
-        else if ($acc__0[0] === 8) {
-          $msg = $acc__0[2];
-          $p__3 = $acc__0[1];
-          $bufput_acc->contents($b, $p__3);
-          return $call1($Pervasives[1], $msg);
-        }
-        else if ($acc__0[0] === 2) {}
-        else if ($acc__0[0] === 4) {
-          $s__0 = $acc__0[2];
-          $p__0 = $acc__0[1];
-          $bufput_acc->contents($b, $p__0);
-          return $call2($Buffer[14], $b, $s__0);
-        }
+      for (;;) {
+        if ($is_int($acc__0)) {return 0;}
         else {
-          $c = $acc__0[2];
-          $p__1 = $acc__0[1];
-          $bufput_acc->contents($b, $p__1);
-          return $call2($Buffer[10], $b, $c);
+          $continue_label = null;
+          switch($acc__0[0]) {
+            // FALLTHROUGH
+            case 0:
+              $fmting_lit = $acc__0[2];
+              $p = $acc__0[1];
+              $s = $string_of_formatting_lit($fmting_lit);
+              $bufput_acc->contents($b, $p);
+              return $call2($Buffer[14], $b, $s);
+            // FALLTHROUGH
+            case 1:
+              $bw = $acc__0[2];
+              $bx = $acc__0[1];
+              if (0 === $bw[0]) {
+                $acc__1 = $bw[1];
+                $bufput_acc->contents($b, $bx);
+                $call2($Buffer[14], $b, $cst__19);
+                $acc__0 = $acc__1;
+                $continue_label = "switch";break;
+              }
+              $acc__2 = $bw[1];
+              $bufput_acc->contents($b, $bx);
+              $call2($Buffer[14], $b, $cst__20);
+              $acc__0 = $acc__2;
+              $continue_label = "switch";break;
+            // FALLTHROUGH
+            case 6:
+              $f = $acc__0[2];
+              $p__2 = $acc__0[1];
+              $bufput_acc->contents($b, $p__2);
+              return $call1($f, $b);
+            // FALLTHROUGH
+            case 7:
+              $acc__3 = $acc__0[1];
+              $acc__0 = $acc__3;
+              $continue_label = "switch";break;
+            // FALLTHROUGH
+            case 8:
+              $msg = $acc__0[2];
+              $p__3 = $acc__0[1];
+              $bufput_acc->contents($b, $p__3);
+              return $call1($Pervasives[1], $msg);
+            // FALLTHROUGH
+            case 2:
+            // FALLTHROUGH
+            case 4:
+              $s__0 = $acc__0[2];
+              $p__0 = $acc__0[1];
+              $bufput_acc->contents($b, $p__0);
+              return $call2($Buffer[14], $b, $s__0);
+            // FALLTHROUGH
+            default:
+              $c = $acc__0[2];
+              $p__1 = $acc__0[1];
+              $bufput_acc->contents($b, $p__1);
+              return $call2($Buffer[10], $b, $c);
+            }
+          if ($continue_label === "switch") {continue;}
         }
       }
     };
     $strput_acc->contents = function(dynamic $b, dynamic $acc) use ($Buffer,$Pervasives,$call1,$call2,$cst__21,$cst__22,$is_int,$string_of_formatting_lit,$strput_acc) {
       $acc__0 = $acc;
-      for (;;) if (
-        $is_int($acc__0)
-      ) {return 0;}
-      else {
-        if ($acc__0[0] === 0) {
-          $fmting_lit = $acc__0[2];
-          $p = $acc__0[1];
-          $s = $string_of_formatting_lit($fmting_lit);
-          $strput_acc->contents($b, $p);
-          return $call2($Buffer[14], $b, $s);
-        }
-        else if ($acc__0[0] === 1) {
-          $bt = $acc__0[2];
-          $bu = $acc__0[1];
-          if (0 === $bt[0]) {
-            $acc__1 = $bt[1];
-            $strput_acc->contents($b, $bu);
-            $call2($Buffer[14], $b, $cst__21);
-            $acc__0 = $acc__1;
-            continue;
-          }
-          $acc__2 = $bt[1];
-          $strput_acc->contents($b, $bu);
-          $call2($Buffer[14], $b, $cst__22);
-          $acc__0 = $acc__2;
-          continue;
-        }
-        else if ($acc__0[0] === 6) {
-          $f = $acc__0[2];
-          $p__2 = $acc__0[1];
-          $strput_acc->contents($b, $p__2);
-          $bv = $call1($f, 0);
-          return $call2($Buffer[14], $b, $bv);
-        }
-        else if ($acc__0[0] === 7) {
-          $acc__3 = $acc__0[1];$acc__0 = $acc__3;continue;
-        }
-        else if ($acc__0[0] === 8) {
-          $msg = $acc__0[2];
-          $p__3 = $acc__0[1];
-          $strput_acc->contents($b, $p__3);
-          return $call1($Pervasives[1], $msg);
-        }
-        else if ($acc__0[0] === 2) {}
-        else if ($acc__0[0] === 4) {
-          $s__0 = $acc__0[2];
-          $p__0 = $acc__0[1];
-          $strput_acc->contents($b, $p__0);
-          return $call2($Buffer[14], $b, $s__0);
-        }
+      for (;;) {
+        if ($is_int($acc__0)) {return 0;}
         else {
-          $c = $acc__0[2];
-          $p__1 = $acc__0[1];
-          $strput_acc->contents($b, $p__1);
-          return $call2($Buffer[10], $b, $c);
+          $continue_label = null;
+          switch($acc__0[0]) {
+            // FALLTHROUGH
+            case 0:
+              $fmting_lit = $acc__0[2];
+              $p = $acc__0[1];
+              $s = $string_of_formatting_lit($fmting_lit);
+              $strput_acc->contents($b, $p);
+              return $call2($Buffer[14], $b, $s);
+            // FALLTHROUGH
+            case 1:
+              $bt = $acc__0[2];
+              $bu = $acc__0[1];
+              if (0 === $bt[0]) {
+                $acc__1 = $bt[1];
+                $strput_acc->contents($b, $bu);
+                $call2($Buffer[14], $b, $cst__21);
+                $acc__0 = $acc__1;
+                $continue_label = "switch";break;
+              }
+              $acc__2 = $bt[1];
+              $strput_acc->contents($b, $bu);
+              $call2($Buffer[14], $b, $cst__22);
+              $acc__0 = $acc__2;
+              $continue_label = "switch";break;
+            // FALLTHROUGH
+            case 6:
+              $f = $acc__0[2];
+              $p__2 = $acc__0[1];
+              $strput_acc->contents($b, $p__2);
+              $bv = $call1($f, 0);
+              return $call2($Buffer[14], $b, $bv);
+            // FALLTHROUGH
+            case 7:
+              $acc__3 = $acc__0[1];
+              $acc__0 = $acc__3;
+              $continue_label = "switch";break;
+            // FALLTHROUGH
+            case 8:
+              $msg = $acc__0[2];
+              $p__3 = $acc__0[1];
+              $strput_acc->contents($b, $p__3);
+              return $call1($Pervasives[1], $msg);
+            // FALLTHROUGH
+            case 2:
+            // FALLTHROUGH
+            case 4:
+              $s__0 = $acc__0[2];
+              $p__0 = $acc__0[1];
+              $strput_acc->contents($b, $p__0);
+              return $call2($Buffer[14], $b, $s__0);
+            // FALLTHROUGH
+            default:
+              $c = $acc__0[2];
+              $p__1 = $acc__0[1];
+              $strput_acc->contents($b, $p__1);
+              return $call2($Buffer[10], $b, $c);
+            }
+          if ($continue_label === "switch") {continue;}
         }
       }
     };
@@ -6233,36 +6304,40 @@ final class CamlinternalFormat {
             $match = $caml_string_get($str, $str_ind__0);
             $switcher = (int) ($match + -32);
             if (! (16 < $unsigned_right_shift_32($switcher, 0))) {
-              if ($switcher === 0) {
-                $set_flag($str_ind__0, $space);
-                $str_ind__1 = (int) ($str_ind__0 + 1);
-                $str_ind__0 = $str_ind__1;
-                continue;
-              }
-              else if ($switcher === 3) {
-                $set_flag($str_ind__0, $hash);
-                $str_ind__2 = (int) ($str_ind__0 + 1);
-                $str_ind__0 = $str_ind__2;
-                continue;
-              }
-              else if ($switcher === 11) {
-                $set_flag($str_ind__0, $plus);
-                $str_ind__3 = (int) ($str_ind__0 + 1);
-                $str_ind__0 = $str_ind__3;
-                continue;
-              }
-              else if ($switcher === 13) {
-                $set_flag($str_ind__0, $minus);
-                $str_ind__4 = (int) ($str_ind__0 + 1);
-                $str_ind__0 = $str_ind__4;
-                continue;
-              }
-              else if ($switcher === 16) {
-                $set_flag($str_ind__0, $zero);
-                $str_ind__5 = (int) ($str_ind__0 + 1);
-                $str_ind__0 = $str_ind__5;
-                continue;
-              }
+              $continue_label = null;
+              switch($switcher) {
+                // FALLTHROUGH
+                case 0:
+                  $set_flag($str_ind__0, $space);
+                  $str_ind__1 = (int) ($str_ind__0 + 1);
+                  $str_ind__0 = $str_ind__1;
+                  $continue_label = "switch";break;
+                // FALLTHROUGH
+                case 3:
+                  $set_flag($str_ind__0, $hash);
+                  $str_ind__2 = (int) ($str_ind__0 + 1);
+                  $str_ind__0 = $str_ind__2;
+                  $continue_label = "switch";break;
+                // FALLTHROUGH
+                case 11:
+                  $set_flag($str_ind__0, $plus);
+                  $str_ind__3 = (int) ($str_ind__0 + 1);
+                  $str_ind__0 = $str_ind__3;
+                  $continue_label = "switch";break;
+                // FALLTHROUGH
+                case 13:
+                  $set_flag($str_ind__0, $minus);
+                  $str_ind__4 = (int) ($str_ind__0 + 1);
+                  $str_ind__0 = $str_ind__4;
+                  $continue_label = "switch";break;
+                // FALLTHROUGH
+                case 16:
+                  $set_flag($str_ind__0, $zero);
+                  $str_ind__5 = (int) ($str_ind__0 + 1);
+                  $str_ind__0 = $str_ind__5;
+                  $continue_label = "switch";break;
+                }
+              if ($continue_label === "switch") {continue;}
             }
             return $parse_padding->contents(
               $pct_ind,
@@ -7788,26 +7863,31 @@ final class CamlinternalFormat {
               if (123 <= $match__0) {
                 if (! (126 <= $match__0)) {
                   $switcher = (int) ($match__0 + -123);
-                  if ($switcher === 0) {
-                    $sub_end = $search_subformat_end->contents(
-                      (int)
-                      ($str_ind__0 + 2),
-                      $end_ind,
-                      125
-                    );
-                    $str_ind__2 = (int) ($sub_end + 2);
-                    $str_ind__0 = $str_ind__2;
-                    continue;
-                  }
-                  else if ($switcher === 1) {break;}
-                  else {
-                    return $expected_character(
-                      (int)
-                      ($str_ind__0 + 1),
-                      $cst_character,
-                      125
-                    );
-                  }
+                  $continue_label = null;
+                  switch($switcher) {
+                    // FALLTHROUGH
+                    case 0:
+                      $sub_end = $search_subformat_end->contents(
+                        (int)
+                        ($str_ind__0 + 2),
+                        $end_ind,
+                        125
+                      );
+                      $str_ind__2 = (int) ($sub_end + 2);
+                      $str_ind__0 = $str_ind__2;
+                      $continue_label = "switch";break;
+                    // FALLTHROUGH
+                    case 1:break;
+                    // FALLTHROUGH
+                    default:
+                      return $expected_character(
+                        (int)
+                        ($str_ind__0 + 1),
+                        $cst_character,
+                        125
+                      );
+                    }
+                  if ($continue_label === "switch") {continue;}
                 }
               }
               else {
@@ -7997,26 +8077,38 @@ final class CamlinternalFormat {
           if (! $switch__0) {
             $switcher__0 = (int) ($symb + -88);
             if (! (32 < $unsigned_right_shift_32($switcher__0, 0))) {
-              if ($switcher__0 === 0) {
-                if ($legacy_behavior__0) {return 9;}break;
-              }
-              else if ($switcher__0 === 23) {
-                if ($legacy_behavior__0) {return 11;}break;
-              }
-              else if ($switcher__0 === 32) {
-                if ($legacy_behavior__0) {return 7;}break;
-              }
-              else if ($switcher__0 === 12) {}
-              else if ($switcher__0 === 17) {}
-              else if ($switcher__0 === 29) {
-                if ($legacy_behavior__0) {$hash__0 = 0;continue;}
-                return $incompatible_flag->contents(
-                  $pct_ind,
-                  $str_ind,
-                  $symb,
-                  $cst__36
-                );
-              }
+              $continue_label = null;
+              switch($switcher__0) {
+                // FALLTHROUGH
+                case 0:
+                  if ($legacy_behavior__0) {return 9;}
+                  break;
+                // FALLTHROUGH
+                case 23:
+                  if ($legacy_behavior__0) {return 11;}
+                  break;
+                // FALLTHROUGH
+                case 32:
+                  if ($legacy_behavior__0) {return 7;}
+                  break;
+                // FALLTHROUGH
+                case 12:
+                // FALLTHROUGH
+                case 17:
+                // FALLTHROUGH
+                case 29:
+                  if ($legacy_behavior__0) {
+                    $hash__0 = 0;
+                    $continue_label = "switch";break;
+                  }
+                  return $incompatible_flag->contents(
+                    $pct_ind,
+                    $str_ind,
+                    $symb,
+                    $cst__36
+                  );
+                }
+              if ($continue_label === "switch") {continue;}
             }
           }
           if (0 === $plus__0) {
@@ -8141,17 +8233,38 @@ final class CamlinternalFormat {
             if (73 <= $symb) {
               $switcher__3 = (int) ($symb + -101);
               if (! (3 < $unsigned_right_shift_32($switcher__3, 0))) {
-                if ($switcher__3 === 0) {return 4;}
-                else if ($switcher__3 === 1) {return 1;}
-                else if ($switcher__3 === 2) {return 10;}else {return 17;}
+                switch($switcher__3) {
+                  // FALLTHROUGH
+                  case 0:
+                    return 4;
+                  // FALLTHROUGH
+                  case 1:
+                    return 1;
+                  // FALLTHROUGH
+                  case 2:
+                    return 10;
+                  // FALLTHROUGH
+                  default:
+                    return 17;
+                  }
               }
             }
             else {
               if (69 <= $symb) {
                 $switcher__4 = (int) ($symb + -69);
-                if ($switcher__4 === 0) {return 7;}
-                else if ($switcher__4 === 1) {break;}
-                else if ($switcher__4 === 2) {return 13;}else {return 20;}
+                switch($switcher__4) {
+                  // FALLTHROUGH
+                  case 0:
+                    return 7;
+                  // FALLTHROUGH
+                  case 1:break;
+                  // FALLTHROUGH
+                  case 2:
+                    return 13;
+                  // FALLTHROUGH
+                  default:
+                    return 20;
+                  }
               }
             }
             if ($legacy_behavior__0) {$plus__0 = 0;continue;}

--- a/rehack_tests/stdlib/stdlib.cma.php/Ephemeron.php
+++ b/rehack_tests/stdlib/stdlib.cma.php/Ephemeron.php
@@ -230,13 +230,22 @@ final class Ephemeron {
               $hk = $param__0[1];
               if ($hkey === $hk) {
                 $match = $call2($H[3], $c, $key);
-                if ($match === 0) {
-                  $h[1] = (int) ($h[1] + -1);return $next;
-                }
-                else if ($match === 1) {
-                  return Vector{0, $hk, $c, $remove_bucket->contents($next)};
-                }
-                else {$h[1] = (int) ($h[1] + -1);$param__0 = $next;continue;}
+                $continue_label = null;
+                switch($match) {
+                  // FALLTHROUGH
+                  case 0:
+                    $h[1] = (int) ($h[1] + -1);
+                    return $next;
+                  // FALLTHROUGH
+                  case 1:
+                    return Vector{0, $hk, $c, $remove_bucket->contents($next)};
+                  // FALLTHROUGH
+                  default:
+                    $h[1] = (int) ($h[1] + -1);
+                    $param__0 = $next;
+                    $continue_label = "switch";break;
+                  }
+                if ($continue_label === "switch") {continue;}
               }
               return Vector{0, $hk, $c, $remove_bucket->contents($next)};
             }
@@ -257,16 +266,24 @@ final class Ephemeron {
             $hk = $param__0[1];
             if ($hkey === $hk) {
               $match = $call2($H[3], $c, $key);
-              if ($match === 0) {
-                $match__0 = $call1($H[4], $c);
-                if ($match__0) {$d = $match__0[1];return $d;}
-                $param__0 = $rest;
-                continue;
-              }
-              else if ($match === 1) {
-                $param__0 = $rest;continue;
-              }
-              else {$param__0 = $rest;continue;}
+              $continue_label = null;
+              switch($match) {
+                // FALLTHROUGH
+                case 0:
+                  $match__0 = $call1($H[4], $c);
+                  if ($match__0) {$d = $match__0[1];return $d;}
+                  $param__0 = $rest;
+                  $continue_label = "switch";break;
+                // FALLTHROUGH
+                case 1:
+                  $param__0 = $rest;
+                  $continue_label = "switch";break;
+                // FALLTHROUGH
+                default:
+                  $param__0 = $rest;
+                  $continue_label = "switch";break;
+                }
+              if ($continue_label === "switch") {continue;}
             }
             $param__0 = $rest;
             continue;
@@ -288,16 +305,24 @@ final class Ephemeron {
             $hk = $param__0[1];
             if ($hkey === $hk) {
               $match = $call2($H[3], $c, $key);
-              if ($match === 0) {
-                $d = $call1($H[4], $c);
-                if ($d) {return $d;}
-                $param__0 = $rest;
-                continue;
-              }
-              else if ($match === 1) {
-                $param__0 = $rest;continue;
-              }
-              else {$param__0 = $rest;continue;}
+              $continue_label = null;
+              switch($match) {
+                // FALLTHROUGH
+                case 0:
+                  $d = $call1($H[4], $c);
+                  if ($d) {return $d;}
+                  $param__0 = $rest;
+                  $continue_label = "switch";break;
+                // FALLTHROUGH
+                case 1:
+                  $param__0 = $rest;
+                  $continue_label = "switch";break;
+                // FALLTHROUGH
+                default:
+                  $param__0 = $rest;
+                  $continue_label = "switch";break;
+                }
+              if ($continue_label === "switch") {continue;}
             }
             $param__0 = $rest;
             continue;
@@ -326,19 +351,27 @@ final class Ephemeron {
               $hk = $param__0[1];
               if ($hkey === $hk) {
                 $match = $call2($H[3], $c, $key);
-                if ($match === 0) {
-                  $match__0 = $call1($H[4], $c);
-                  if ($match__0) {
-                    $d = $match__0[1];
-                    return Vector{0, $d, $find_in_bucket->contents($rest)};
+                $continue_label = null;
+                switch($match) {
+                  // FALLTHROUGH
+                  case 0:
+                    $match__0 = $call1($H[4], $c);
+                    if ($match__0) {
+                      $d = $match__0[1];
+                      return Vector{0, $d, $find_in_bucket->contents($rest)};
+                    }
+                    $param__0 = $rest;
+                    $continue_label = "switch";break;
+                  // FALLTHROUGH
+                  case 1:
+                    $param__0 = $rest;
+                    $continue_label = "switch";break;
+                  // FALLTHROUGH
+                  default:
+                    $param__0 = $rest;
+                    $continue_label = "switch";break;
                   }
-                  $param__0 = $rest;
-                  continue;
-                }
-                else if ($match === 1) {
-                  $param__0 = $rest;continue;
-                }
-                else {$param__0 = $rest;continue;}
+                if ($continue_label === "switch") {continue;}
               }
               $param__0 = $rest;
               continue;

--- a/rehack_tests/stdlib/stdlib.cma.php/Ephemeron.php
+++ b/rehack_tests/stdlib/stdlib.cma.php/Ephemeron.php
@@ -243,9 +243,9 @@ final class Ephemeron {
                   default:
                     $h[1] = (int) ($h[1] + -1);
                     $param__0 = $next;
-                    $continue_label = "switch";break;
+                    $continue_label = "#";break;
                   }
-                if ($continue_label === "switch") {continue;}
+                if ($continue_label === "#") {continue;}
               }
               return Vector{0, $hk, $c, $remove_bucket->contents($next)};
             }
@@ -273,17 +273,17 @@ final class Ephemeron {
                   $match__0 = $call1($H[4], $c);
                   if ($match__0) {$d = $match__0[1];return $d;}
                   $param__0 = $rest;
-                  $continue_label = "switch";break;
+                  $continue_label = "#";break;
                 // FALLTHROUGH
                 case 1:
                   $param__0 = $rest;
-                  $continue_label = "switch";break;
+                  $continue_label = "#";break;
                 // FALLTHROUGH
                 default:
                   $param__0 = $rest;
-                  $continue_label = "switch";break;
+                  $continue_label = "#";break;
                 }
-              if ($continue_label === "switch") {continue;}
+              if ($continue_label === "#") {continue;}
             }
             $param__0 = $rest;
             continue;
@@ -312,17 +312,17 @@ final class Ephemeron {
                   $d = $call1($H[4], $c);
                   if ($d) {return $d;}
                   $param__0 = $rest;
-                  $continue_label = "switch";break;
+                  $continue_label = "#";break;
                 // FALLTHROUGH
                 case 1:
                   $param__0 = $rest;
-                  $continue_label = "switch";break;
+                  $continue_label = "#";break;
                 // FALLTHROUGH
                 default:
                   $param__0 = $rest;
-                  $continue_label = "switch";break;
+                  $continue_label = "#";break;
                 }
-              if ($continue_label === "switch") {continue;}
+              if ($continue_label === "#") {continue;}
             }
             $param__0 = $rest;
             continue;
@@ -361,17 +361,17 @@ final class Ephemeron {
                       return Vector{0, $d, $find_in_bucket->contents($rest)};
                     }
                     $param__0 = $rest;
-                    $continue_label = "switch";break;
+                    $continue_label = "#";break;
                   // FALLTHROUGH
                   case 1:
                     $param__0 = $rest;
-                    $continue_label = "switch";break;
+                    $continue_label = "#";break;
                   // FALLTHROUGH
                   default:
                     $param__0 = $rest;
-                    $continue_label = "switch";break;
+                    $continue_label = "#";break;
                   }
-                if ($continue_label === "switch") {continue;}
+                if ($continue_label === "#") {continue;}
               }
               $param__0 = $rest;
               continue;

--- a/rehack_tests/stdlib/stdlib.cma.php/Genlex.php
+++ b/rehack_tests/stdlib/stdlib.cma.php/Genlex.php
@@ -319,83 +319,120 @@ final class Genlex {
                 }
                 else {
                   $switcher = (int) ($m + 65);
-                  if ($switcher === 34) {
-                    $call1($Stream[12], $strm);
-                    $reset_buffer(0);
-                    return Vector{0, Vector{4, $string($strm)}};
-                  }
-                  else if ($switcher === 39) {
-                    $call1($Stream[12], $strm);
-                    try {$c = $char__0->contents($strm);}
-                    catch(\Throwable $o) {
-                      $o = $caml_wrap_exception($o);
-                      if ($o === $Stream[1]) {
-                        throw $runtime["caml_wrap_thrown_exception"](Vector{0, $Stream[2], $cst}) as \Throwable;
+                  $continue_label = null;
+                  switch($switcher) {
+                    // FALLTHROUGH
+                    case 34:
+                      $call1($Stream[12], $strm);
+                      $reset_buffer(0);
+                      return Vector{0, Vector{4, $string($strm)}};
+                    // FALLTHROUGH
+                    case 39:
+                      $call1($Stream[12], $strm);
+                      try {$c = $char__0->contents($strm);}
+                      catch(\Throwable $o) {
+                        $o = $caml_wrap_exception($o);
+                        if ($o === $Stream[1]) {
+                          throw $runtime["caml_wrap_thrown_exception"](Vector{0, $Stream[2], $cst}) as \Throwable;
+                        }
+                        throw $runtime["caml_wrap_thrown_exception_reraise"]($o) as \Throwable;
                       }
-                      throw $runtime["caml_wrap_thrown_exception_reraise"]($o) as \Throwable;
-                    }
-                    $match__0 = $call1($Stream[11], $strm);
-                    if ($match__0) {
-                      if (39 === $match__0[1]) {
-                        $call1($Stream[12], $strm);
-                        return Vector{0, Vector{5, $c}};
+                      $match__0 = $call1($Stream[11], $strm);
+                      if ($match__0) {
+                        if (39 === $match__0[1]) {
+                          $call1($Stream[12], $strm);
+                          return Vector{0, Vector{5, $c}};
+                        }
                       }
+                      throw $runtime["caml_wrap_thrown_exception"](Vector{0, $Stream[2], $cst__0}) as \Throwable;
+                    // FALLTHROUGH
+                    case 40:
+                      $call1($Stream[12], $strm);
+                      if ($counter < 50) {
+                        $counter__0 = (int) ($counter + 1);
+                        return $maybe_comment->contents($counter__0, $strm);
+                      }
+                      return $caml_trampoline_return(
+                        $maybe_comment->contents,
+                        varray[0,$strm]
+                      );
+                    // FALLTHROUGH
+                    case 45:
+                      $call1($Stream[12], $strm);
+                      return $neg_number($strm);
+                    // FALLTHROUGH
+                    case 9:
+                    // FALLTHROUGH
+                    case 10:
+                    // FALLTHROUGH
+                    case 12:
+                    // FALLTHROUGH
+                    case 13:
+                    // FALLTHROUGH
+                    case 26:
+                    // FALLTHROUGH
+                    case 32:
+                      $call1($Stream[12], $strm);
+                      $continue_label = "switch";break;
+                    // FALLTHROUGH
+                    case 48:
+                    // FALLTHROUGH
+                    case 49:
+                    // FALLTHROUGH
+                    case 50:
+                    // FALLTHROUGH
+                    case 51:
+                    // FALLTHROUGH
+                    case 52:
+                    // FALLTHROUGH
+                    case 53:
+                    // FALLTHROUGH
+                    case 54:
+                    // FALLTHROUGH
+                    case 55:
+                    // FALLTHROUGH
+                    case 56:
+                    // FALLTHROUGH
+                    case 57:
+                      $call1($Stream[12], $strm);
+                      $reset_buffer(0);
+                      $store($l);
+                      return $number($strm);
+                    // FALLTHROUGH
+                    case 33:
+                    // FALLTHROUGH
+                    case 35:
+                    // FALLTHROUGH
+                    case 36:
+                    // FALLTHROUGH
+                    case 37:
+                    // FALLTHROUGH
+                    case 38:
+                    // FALLTHROUGH
+                    case 42:
+                    // FALLTHROUGH
+                    case 43:
+                    // FALLTHROUGH
+                    case 47:
+                    // FALLTHROUGH
+                    case 58:
+                    // FALLTHROUGH
+                    case 60:
+                    // FALLTHROUGH
+                    case 61:
+                    // FALLTHROUGH
+                    case 62:
+                    // FALLTHROUGH
+                    case 63:
+                    // FALLTHROUGH
+                    case 64:
+                      $switch__0 = 2;
+                      break;
+                    // FALLTHROUGH
+                    default:
+                      $switch__0 = 0;
                     }
-                    throw $runtime["caml_wrap_thrown_exception"](Vector{0, $Stream[2], $cst__0}) as \Throwable;
-                  }
-                  else if ($switcher === 40) {
-                    $call1($Stream[12], $strm);
-                    if ($counter < 50) {
-                      $counter__0 = (int) ($counter + 1);
-                      return $maybe_comment->contents($counter__0, $strm);
-                    }
-                    return $caml_trampoline_return(
-                      $maybe_comment->contents,
-                      varray[0,$strm]
-                    );
-                  }
-                  else if ($switcher === 45) {
-                    $call1($Stream[12], $strm);return $neg_number($strm);
-                  }
-                  else if ($switcher === 9) {}
-                  else if ($switcher === 10) {}
-                  else if ($switcher === 12) {}
-                  else if ($switcher === 13) {}
-                  else if ($switcher === 26) {}
-                  else if ($switcher === 32) {
-                    $call1($Stream[12], $strm);continue;
-                  }
-                  else if ($switcher === 48) {}
-                  else if ($switcher === 49) {}
-                  else if ($switcher === 50) {}
-                  else if ($switcher === 51) {}
-                  else if ($switcher === 52) {}
-                  else if ($switcher === 53) {}
-                  else if ($switcher === 54) {}
-                  else if ($switcher === 55) {}
-                  else if ($switcher === 56) {}
-                  else if ($switcher === 57) {
-                    $call1($Stream[12], $strm);
-                    $reset_buffer(0);
-                    $store($l);
-                    return $number($strm);
-                  }
-                  else if ($switcher === 33) {}
-                  else if ($switcher === 35) {}
-                  else if ($switcher === 36) {}
-                  else if ($switcher === 37) {}
-                  else if ($switcher === 38) {}
-                  else if ($switcher === 42) {}
-                  else if ($switcher === 43) {}
-                  else if ($switcher === 47) {}
-                  else if ($switcher === 58) {}
-                  else if ($switcher === 60) {}
-                  else if ($switcher === 61) {}
-                  else if ($switcher === 62) {}
-                  else if ($switcher === 63) {}
-                  else if ($switcher === 64) {$switch__0 = 2;break;
-                  }
-                  else {$switch__0 = 0;}
+                  if ($continue_label === "switch") {continue;}
                 }
               }
               else {
@@ -420,22 +457,24 @@ final class Genlex {
                 }
               }
             }
-            if ($switch__0 === 0) {
-              $call1($Stream[12], $strm);
-              return Vector{0, $keyword_or_error($l)};
-            }
-            else if ($switch__0 === 1) {
-              $call1($Stream[12], $strm);
-              $reset_buffer(0);
-              $store($l);
-              return $ident($strm);
-            }
-            else {
-              $call1($Stream[12], $strm);
-              $reset_buffer(0);
-              $store($l);
-              return $ident2($strm);
-            }
+            switch($switch__0) {
+              // FALLTHROUGH
+              case 0:
+                $call1($Stream[12], $strm);
+                return Vector{0, $keyword_or_error($l)};
+              // FALLTHROUGH
+              case 1:
+                $call1($Stream[12], $strm);
+                $reset_buffer(0);
+                $store($l);
+                return $ident($strm);
+              // FALLTHROUGH
+              default:
+                $call1($Stream[12], $strm);
+                $reset_buffer(0);
+                $store($l);
+                return $ident2($strm);
+              }
           }
           return 0;
         }

--- a/rehack_tests/stdlib/stdlib.cma.php/Genlex.php
+++ b/rehack_tests/stdlib/stdlib.cma.php/Genlex.php
@@ -373,7 +373,7 @@ final class Genlex {
                     // FALLTHROUGH
                     case 32:
                       $call1($Stream[12], $strm);
-                      $continue_label = "switch";break;
+                      $continue_label = "#";break;
                     // FALLTHROUGH
                     case 48:
                     // FALLTHROUGH
@@ -432,7 +432,7 @@ final class Genlex {
                     default:
                       $switch__0 = 0;
                     }
-                  if ($continue_label === "switch") {continue;}
+                  if ($continue_label === "#") {continue;}
                 }
               }
               else {

--- a/rehack_tests/stdlib/stdlib.cma.php/Parsing.php
+++ b/rehack_tests/stdlib/stdlib.cma.php/Parsing.php
@@ -103,51 +103,61 @@ final class Parsing {
             $cmd__0,
             $arg__0
           );
-          if ($match === 0) {
-            $arg__1 = $call1($lexer, $lexbuf);
-            $env[9] = $lexbuf[11];
-            $env[10] = $lexbuf[12];
-            $cmd__0 = 1;
-            $arg__0 = $arg__1;
-            continue;
-          }
-          else if ($match === 1) {
-            throw $runtime["caml_wrap_thrown_exception"]($Parse_error) as \Throwable;
-          }
-          else if ($match === 2) {
-            $grow_stacks(0);$cmd__0 = 2;$arg__0 = 0;continue;
-          }
-          else if ($match === 3) {
-            $grow_stacks(0);$cmd__0 = 3;$arg__0 = 0;continue;
-          }
-          else if ($match === 4) {
-            try {
-              $m = $env[13];
-              $n = $call1($caml_check_bound($tables[1], $m)[$m + 1], $env);
-              $o = 4;
-              $cmd__1 = $o;
-              $arg__2 = $n;
-            }
-            catch(\Throwable $p) {
-              $p = $caml_wrap_exception($p);
-              if ($p !== $Parse_error) {
-                throw $runtime["caml_wrap_thrown_exception_reraise"]($p) as \Throwable;
+          $continue_label = null;
+          switch($match) {
+            // FALLTHROUGH
+            case 0:
+              $arg__1 = $call1($lexer, $lexbuf);
+              $env[9] = $lexbuf[11];
+              $env[10] = $lexbuf[12];
+              $cmd__0 = 1;
+              $arg__0 = $arg__1;
+              $continue_label = "switch";break;
+            // FALLTHROUGH
+            case 1:
+              throw $runtime["caml_wrap_thrown_exception"]($Parse_error) as \Throwable;
+            // FALLTHROUGH
+            case 2:
+              $grow_stacks(0);
+              $cmd__0 = 2;
+              $arg__0 = 0;
+              $continue_label = "switch";break;
+            // FALLTHROUGH
+            case 3:
+              $grow_stacks(0);
+              $cmd__0 = 3;
+              $arg__0 = 0;
+              $continue_label = "switch";break;
+            // FALLTHROUGH
+            case 4:
+              try {
+                $m = $env[13];
+                $n = $call1($caml_check_bound($tables[1], $m)[$m + 1], $env);
+                $o = 4;
+                $cmd__1 = $o;
+                $arg__2 = $n;
               }
-              $k = 0;
-              $l = 5;
-              $cmd__1 = $l;
-              $arg__2 = $k;
+              catch(\Throwable $p) {
+                $p = $caml_wrap_exception($p);
+                if ($p !== $Parse_error) {
+                  throw $runtime["caml_wrap_thrown_exception_reraise"]($p) as \Throwable;
+                }
+                $k = 0;
+                $l = 5;
+                $cmd__1 = $l;
+                $arg__2 = $k;
+              }
+              $cmd__0 = $cmd__1;
+              $arg__0 = $arg__2;
+              $continue_label = "switch";break;
+            // FALLTHROUGH
+            default:
+              $call1($tables[14], $cst_syntax_error);
+              $cmd__0 = 5;
+              $arg__0 = 0;
+              $continue_label = "switch";break;
             }
-            $cmd__0 = $cmd__1;
-            $arg__0 = $arg__2;
-            continue;
-          }
-          else {
-            $call1($tables[14], $cst_syntax_error);
-            $cmd__0 = 5;
-            $arg__0 = 0;
-            continue;
-          }
+          if ($continue_label === "switch") {continue;}
         }
       };
       $init_asp = $env[11];

--- a/rehack_tests/stdlib/stdlib.cma.php/Parsing.php
+++ b/rehack_tests/stdlib/stdlib.cma.php/Parsing.php
@@ -112,7 +112,7 @@ final class Parsing {
               $env[10] = $lexbuf[12];
               $cmd__0 = 1;
               $arg__0 = $arg__1;
-              $continue_label = "switch";break;
+              $continue_label = "#";break;
             // FALLTHROUGH
             case 1:
               throw $runtime["caml_wrap_thrown_exception"]($Parse_error) as \Throwable;
@@ -121,13 +121,13 @@ final class Parsing {
               $grow_stacks(0);
               $cmd__0 = 2;
               $arg__0 = 0;
-              $continue_label = "switch";break;
+              $continue_label = "#";break;
             // FALLTHROUGH
             case 3:
               $grow_stacks(0);
               $cmd__0 = 3;
               $arg__0 = 0;
-              $continue_label = "switch";break;
+              $continue_label = "#";break;
             // FALLTHROUGH
             case 4:
               try {
@@ -149,15 +149,15 @@ final class Parsing {
               }
               $cmd__0 = $cmd__1;
               $arg__0 = $arg__2;
-              $continue_label = "switch";break;
+              $continue_label = "#";break;
             // FALLTHROUGH
             default:
               $call1($tables[14], $cst_syntax_error);
               $cmd__0 = 5;
               $arg__0 = 0;
-              $continue_label = "switch";break;
+              $continue_label = "#";break;
             }
-          if ($continue_label === "switch") {continue;}
+          if ($continue_label === "#") {continue;}
         }
       };
       $init_asp = $env[11];

--- a/rehack_tests/stdlib/stdlib.cma.php/Scanf.php
+++ b/rehack_tests/stdlib/stdlib.cma.php/Scanf.php
@@ -1428,223 +1428,307 @@ final class Scanf {
     $take_format_readers__0 = function
     (dynamic $counter, dynamic $k, dynamic $fmt) use ($CamlinternalFormat,$CamlinternalFormatBasics,$call1,$call2,$caml_trampoline_return,$is_int,$take_fmtty_format_readers__0,$take_format_readers,$take_ignored_format_readers) {
       $fmt__0 = $fmt;
-      for (;;) if (
-        $is_int($fmt__0)
-      ) {return $call1($k, 0);}
-      else {
-        if ($fmt__0[0] === 0) {
-          $fmt__1 = $fmt__0[1];$fmt__0 = $fmt__1;continue;
+      for (;;) {
+        if ($is_int($fmt__0)) {return $call1($k, 0);
         }
-        else if ($fmt__0[0] === 1) {
-          $fmt__2 = $fmt__0[1];$fmt__0 = $fmt__2;continue;
+        else {
+          $continue_label = null;
+          switch($fmt__0[0]) {
+            // FALLTHROUGH
+            case 0:
+              $fmt__1 = $fmt__0[1];
+              $fmt__0 = $fmt__1;
+              $continue_label = "switch";break;
+            // FALLTHROUGH
+            case 1:
+              $fmt__2 = $fmt__0[1];
+              $fmt__0 = $fmt__2;
+              $continue_label = "switch";break;
+            // FALLTHROUGH
+            case 2:
+              $fmt__3 = $fmt__0[2];
+              $fmt__0 = $fmt__3;
+              $continue_label = "switch";break;
+            // FALLTHROUGH
+            case 3:
+              $fmt__4 = $fmt__0[2];
+              $fmt__0 = $fmt__4;
+              $continue_label = "switch";break;
+            // FALLTHROUGH
+            case 4:
+              $fmt__5 = $fmt__0[4];
+              $fmt__0 = $fmt__5;
+              $continue_label = "switch";break;
+            // FALLTHROUGH
+            case 5:
+              $fmt__6 = $fmt__0[4];
+              $fmt__0 = $fmt__6;
+              $continue_label = "switch";break;
+            // FALLTHROUGH
+            case 6:
+              $fmt__7 = $fmt__0[4];
+              $fmt__0 = $fmt__7;
+              $continue_label = "switch";break;
+            // FALLTHROUGH
+            case 7:
+              $fmt__8 = $fmt__0[4];
+              $fmt__0 = $fmt__8;
+              $continue_label = "switch";break;
+            // FALLTHROUGH
+            case 8:
+              $fmt__9 = $fmt__0[4];
+              $fmt__0 = $fmt__9;
+              $continue_label = "switch";break;
+            // FALLTHROUGH
+            case 9:
+              $fmt__10 = $fmt__0[2];
+              $fmt__0 = $fmt__10;
+              $continue_label = "switch";break;
+            // FALLTHROUGH
+            case 10:
+              $fmt__11 = $fmt__0[1];
+              $fmt__0 = $fmt__11;
+              $continue_label = "switch";break;
+            // FALLTHROUGH
+            case 11:
+              $fmt__12 = $fmt__0[2];
+              $fmt__0 = $fmt__12;
+              $continue_label = "switch";break;
+            // FALLTHROUGH
+            case 12:
+              $fmt__13 = $fmt__0[2];
+              $fmt__0 = $fmt__13;
+              $continue_label = "switch";break;
+            // FALLTHROUGH
+            case 13:
+              $fmt__14 = $fmt__0[3];
+              $fmt__0 = $fmt__14;
+              $continue_label = "switch";break;
+            // FALLTHROUGH
+            case 14:
+              $rest = $fmt__0[3];
+              $fmtty = $fmt__0[2];
+              $an = $call1($CamlinternalFormat[22], $fmtty);
+              $ao = $call1($CamlinternalFormatBasics[2], $an);
+              if ($counter < 50) {
+                $counter__1 = (int) ($counter + 1);
+                return $take_fmtty_format_readers__0->contents(
+                  $counter__1,
+                  $k,
+                  $ao,
+                  $rest
+                );
+              }
+              return $caml_trampoline_return(
+                $take_fmtty_format_readers__0->contents,
+                varray[0,$k,$ao,$rest]
+              );
+            // FALLTHROUGH
+            case 15:
+              $fmt__15 = $fmt__0[1];
+              $fmt__0 = $fmt__15;
+              $continue_label = "switch";break;
+            // FALLTHROUGH
+            case 16:
+              $fmt__16 = $fmt__0[1];
+              $fmt__0 = $fmt__16;
+              $continue_label = "switch";break;
+            // FALLTHROUGH
+            case 17:
+              $fmt__17 = $fmt__0[2];
+              $fmt__0 = $fmt__17;
+              $continue_label = "switch";break;
+            // FALLTHROUGH
+            case 18:
+              $ap = $fmt__0[1];
+              if (0 === $ap[0]) {
+                $rest__0 = $fmt__0[2];
+                $match = $ap[1];
+                $fmt__18 = $match[1];
+                $fmt__19 = $call2(
+                  $CamlinternalFormatBasics[3],
+                  $fmt__18,
+                  $rest__0
+                );
+                $fmt__0 = $fmt__19;
+                $continue_label = "switch";break;
+              }
+              $rest__1 = $fmt__0[2];
+              $match__0 = $ap[1];
+              $fmt__20 = $match__0[1];
+              $fmt__21 = $call2(
+                $CamlinternalFormatBasics[3],
+                $fmt__20,
+                $rest__1
+              );
+              $fmt__0 = $fmt__21;
+              $continue_label = "switch";break;
+            // FALLTHROUGH
+            case 19:
+              $fmt_rest = $fmt__0[1];
+              return function(dynamic $reader) use ($call1,$fmt_rest,$k,$take_format_readers) {
+                $new_k = function(dynamic $readers_rest) use ($call1,$k,$reader) {
+                  return $call1($k, Vector{0, $reader, $readers_rest});
+                };
+                return $take_format_readers->contents($new_k, $fmt_rest);
+              };
+            // FALLTHROUGH
+            case 20:
+              $fmt__22 = $fmt__0[3];
+              $fmt__0 = $fmt__22;
+              $continue_label = "switch";break;
+            // FALLTHROUGH
+            case 21:
+              $fmt__23 = $fmt__0[2];
+              $fmt__0 = $fmt__23;
+              $continue_label = "switch";break;
+            // FALLTHROUGH
+            case 22:
+              $fmt__24 = $fmt__0[1];
+              $fmt__0 = $fmt__24;
+              $continue_label = "switch";break;
+            // FALLTHROUGH
+            case 23:
+              $rest__2 = $fmt__0[2];
+              $ign = $fmt__0[1];
+              if ($counter < 50) {
+                $counter__0 = (int) ($counter + 1);
+                return $take_ignored_format_readers->contents(
+                  $counter__0,
+                  $k,
+                  $ign,
+                  $rest__2
+                );
+              }
+              return $caml_trampoline_return(
+                $take_ignored_format_readers->contents,
+                varray[0,$k,$ign,$rest__2]
+              );
+            // FALLTHROUGH
+            default:
+              $fmt__25 = $fmt__0[3];
+              $fmt__0 = $fmt__25;
+              $continue_label = "switch";break;
+            }
+          if ($continue_label === "switch") {continue;}
         }
-        else if ($fmt__0[0] === 2) {
-          $fmt__3 = $fmt__0[2];$fmt__0 = $fmt__3;continue;
-        }
-        else if ($fmt__0[0] === 3) {
-          $fmt__4 = $fmt__0[2];$fmt__0 = $fmt__4;continue;
-        }
-        else if ($fmt__0[0] === 4) {
-          $fmt__5 = $fmt__0[4];$fmt__0 = $fmt__5;continue;
-        }
-        else if ($fmt__0[0] === 5) {
-          $fmt__6 = $fmt__0[4];$fmt__0 = $fmt__6;continue;
-        }
-        else if ($fmt__0[0] === 6) {
-          $fmt__7 = $fmt__0[4];$fmt__0 = $fmt__7;continue;
-        }
-        else if ($fmt__0[0] === 7) {
-          $fmt__8 = $fmt__0[4];$fmt__0 = $fmt__8;continue;
-        }
-        else if ($fmt__0[0] === 8) {
-          $fmt__9 = $fmt__0[4];$fmt__0 = $fmt__9;continue;
-        }
-        else if ($fmt__0[0] === 9) {
-          $fmt__10 = $fmt__0[2];$fmt__0 = $fmt__10;continue;
-        }
-        else if ($fmt__0[0] === 10) {
-          $fmt__11 = $fmt__0[1];$fmt__0 = $fmt__11;continue;
-        }
-        else if ($fmt__0[0] === 11) {
-          $fmt__12 = $fmt__0[2];$fmt__0 = $fmt__12;continue;
-        }
-        else if ($fmt__0[0] === 12) {
-          $fmt__13 = $fmt__0[2];$fmt__0 = $fmt__13;continue;
-        }
-        else if ($fmt__0[0] === 13) {
-          $fmt__14 = $fmt__0[3];$fmt__0 = $fmt__14;continue;
-        }
-        else if ($fmt__0[0] === 14) {
-          $rest = $fmt__0[3];
-          $fmtty = $fmt__0[2];
-          $an = $call1($CamlinternalFormat[22], $fmtty);
-          $ao = $call1($CamlinternalFormatBasics[2], $an);
-          if ($counter < 50) {
-            $counter__1 = (int) ($counter + 1);
-            return $take_fmtty_format_readers__0->contents(
-              $counter__1,
-              $k,
-              $ao,
-              $rest
-            );
-          }
-          return $caml_trampoline_return(
-            $take_fmtty_format_readers__0->contents,
-            varray[0,$k,$ao,$rest]
-          );
-        }
-        else if ($fmt__0[0] === 15) {
-          $fmt__15 = $fmt__0[1];$fmt__0 = $fmt__15;continue;
-        }
-        else if ($fmt__0[0] === 16) {
-          $fmt__16 = $fmt__0[1];$fmt__0 = $fmt__16;continue;
-        }
-        else if ($fmt__0[0] === 17) {
-          $fmt__17 = $fmt__0[2];$fmt__0 = $fmt__17;continue;
-        }
-        else if ($fmt__0[0] === 18) {
-          $ap = $fmt__0[1];
-          if (0 === $ap[0]) {
-            $rest__0 = $fmt__0[2];
-            $match = $ap[1];
-            $fmt__18 = $match[1];
-            $fmt__19 = $call2($CamlinternalFormatBasics[3], $fmt__18, $rest__0
-            );
-            $fmt__0 = $fmt__19;
-            continue;
-          }
-          $rest__1 = $fmt__0[2];
-          $match__0 = $ap[1];
-          $fmt__20 = $match__0[1];
-          $fmt__21 = $call2($CamlinternalFormatBasics[3], $fmt__20, $rest__1);
-          $fmt__0 = $fmt__21;
-          continue;
-        }
-        else if ($fmt__0[0] === 19) {
-          $fmt_rest = $fmt__0[1];
-          return function(dynamic $reader) use ($call1,$fmt_rest,$k,$take_format_readers) {
-            $new_k = function(dynamic $readers_rest) use ($call1,$k,$reader) {
-              return $call1($k, Vector{0, $reader, $readers_rest});
-            };
-            return $take_format_readers->contents($new_k, $fmt_rest);
-          };
-        }
-        else if ($fmt__0[0] === 20) {
-          $fmt__22 = $fmt__0[3];$fmt__0 = $fmt__22;continue;
-        }
-        else if ($fmt__0[0] === 21) {
-          $fmt__23 = $fmt__0[2];$fmt__0 = $fmt__23;continue;
-        }
-        else if ($fmt__0[0] === 22) {
-          $fmt__24 = $fmt__0[1];$fmt__0 = $fmt__24;continue;
-        }
-        else if ($fmt__0[0] === 23) {
-          $rest__2 = $fmt__0[2];
-          $ign = $fmt__0[1];
-          if ($counter < 50) {
-            $counter__0 = (int) ($counter + 1);
-            return $take_ignored_format_readers->contents(
-              $counter__0,
-              $k,
-              $ign,
-              $rest__2
-            );
-          }
-          return $caml_trampoline_return(
-            $take_ignored_format_readers->contents,
-            varray[0,$k,$ign,$rest__2]
-          );
-        }
-        else {$fmt__25 = $fmt__0[3];$fmt__0 = $fmt__25;continue;}
       }
     };
     $take_fmtty_format_readers__0->contents = function
     (dynamic $counter, dynamic $k, dynamic $fmtty, dynamic $fmt) use ($CamlinternalFormat,$CamlinternalFormatBasics,$call1,$call2,$caml_trampoline_return,$is_int,$take_fmtty_format_readers,$take_format_readers__0) {
       $fmtty__0 = $fmtty;
-      for (;;) if (
-        $is_int($fmtty__0)
-      ) {
-        if ($counter < 50) {
-          $counter__0 = (int) ($counter + 1);
-          return $take_format_readers__0($counter__0, $k, $fmt);
-        }
-        return $caml_trampoline_return(
-          $take_format_readers__0,
-          varray[0,$k,$fmt]
-        );
-      }
-      else {
-        if ($fmtty__0[0] === 0) {
-          $fmtty__1 = $fmtty__0[1];$fmtty__0 = $fmtty__1;continue;
-        }
-        else if ($fmtty__0[0] === 1) {
-          $fmtty__2 = $fmtty__0[1];$fmtty__0 = $fmtty__2;continue;
-        }
-        else if ($fmtty__0[0] === 2) {
-          $fmtty__3 = $fmtty__0[1];$fmtty__0 = $fmtty__3;continue;
-        }
-        else if ($fmtty__0[0] === 3) {
-          $fmtty__4 = $fmtty__0[1];$fmtty__0 = $fmtty__4;continue;
-        }
-        else if ($fmtty__0[0] === 4) {
-          $fmtty__5 = $fmtty__0[1];$fmtty__0 = $fmtty__5;continue;
-        }
-        else if ($fmtty__0[0] === 5) {
-          $fmtty__6 = $fmtty__0[1];$fmtty__0 = $fmtty__6;continue;
-        }
-        else if ($fmtty__0[0] === 6) {
-          $fmtty__7 = $fmtty__0[1];$fmtty__0 = $fmtty__7;continue;
-        }
-        else if ($fmtty__0[0] === 7) {
-          $fmtty__8 = $fmtty__0[1];$fmtty__0 = $fmtty__8;continue;
-        }
-        else if ($fmtty__0[0] === 8) {
-          $fmtty__9 = $fmtty__0[2];$fmtty__0 = $fmtty__9;continue;
-        }
-        else if ($fmtty__0[0] === 9) {
-          $rest = $fmtty__0[3];
-          $ty2 = $fmtty__0[2];
-          $ty1 = $fmtty__0[1];
-          $am = $call1($CamlinternalFormat[22], $ty1);
-          $ty = $call2($CamlinternalFormat[23], $am, $ty2);
-          $fmtty__10 = $call2($CamlinternalFormatBasics[1], $ty, $rest);
-          $fmtty__0 = $fmtty__10;
-          continue;
-        }
-        else if ($fmtty__0[0] === 10) {
-          $fmtty__11 = $fmtty__0[1];$fmtty__0 = $fmtty__11;continue;
-        }
-        else if ($fmtty__0[0] === 11) {
-          $fmtty__12 = $fmtty__0[1];$fmtty__0 = $fmtty__12;continue;
-        }
-        else if ($fmtty__0[0] === 12) {
-          $fmtty__13 = $fmtty__0[1];$fmtty__0 = $fmtty__13;continue;
-        }
-        else if ($fmtty__0[0] === 13) {
-          $fmt_rest = $fmtty__0[1];
-          return function(dynamic $reader) use ($call1,$fmt,$fmt_rest,$k,$take_fmtty_format_readers) {
-            $new_k = function(dynamic $readers_rest) use ($call1,$k,$reader) {
-              return $call1($k, Vector{0, $reader, $readers_rest});
-            };
-            return $take_fmtty_format_readers->contents(
-              $new_k,
-              $fmt_rest,
-              $fmt
-            );
-          };
+      for (;;) {
+        if ($is_int($fmtty__0)) {
+          if ($counter < 50) {
+            $counter__0 = (int) ($counter + 1);
+            return $take_format_readers__0($counter__0, $k, $fmt);
+          }
+          return $caml_trampoline_return(
+            $take_format_readers__0,
+            varray[0,$k,$fmt]
+          );
         }
         else {
-          $fmt_rest__0 = $fmtty__0[1];
-          return function(dynamic $reader) use ($call1,$fmt,$fmt_rest__0,$k,$take_fmtty_format_readers) {
-            $new_k = function(dynamic $readers_rest) use ($call1,$k,$reader) {
-              return $call1($k, Vector{0, $reader, $readers_rest});
-            };
-            return $take_fmtty_format_readers->contents(
-              $new_k,
-              $fmt_rest__0,
-              $fmt
-            );
-          };
+          $continue_label = null;
+          switch($fmtty__0[0]) {
+            // FALLTHROUGH
+            case 0:
+              $fmtty__1 = $fmtty__0[1];
+              $fmtty__0 = $fmtty__1;
+              $continue_label = "switch";break;
+            // FALLTHROUGH
+            case 1:
+              $fmtty__2 = $fmtty__0[1];
+              $fmtty__0 = $fmtty__2;
+              $continue_label = "switch";break;
+            // FALLTHROUGH
+            case 2:
+              $fmtty__3 = $fmtty__0[1];
+              $fmtty__0 = $fmtty__3;
+              $continue_label = "switch";break;
+            // FALLTHROUGH
+            case 3:
+              $fmtty__4 = $fmtty__0[1];
+              $fmtty__0 = $fmtty__4;
+              $continue_label = "switch";break;
+            // FALLTHROUGH
+            case 4:
+              $fmtty__5 = $fmtty__0[1];
+              $fmtty__0 = $fmtty__5;
+              $continue_label = "switch";break;
+            // FALLTHROUGH
+            case 5:
+              $fmtty__6 = $fmtty__0[1];
+              $fmtty__0 = $fmtty__6;
+              $continue_label = "switch";break;
+            // FALLTHROUGH
+            case 6:
+              $fmtty__7 = $fmtty__0[1];
+              $fmtty__0 = $fmtty__7;
+              $continue_label = "switch";break;
+            // FALLTHROUGH
+            case 7:
+              $fmtty__8 = $fmtty__0[1];
+              $fmtty__0 = $fmtty__8;
+              $continue_label = "switch";break;
+            // FALLTHROUGH
+            case 8:
+              $fmtty__9 = $fmtty__0[2];
+              $fmtty__0 = $fmtty__9;
+              $continue_label = "switch";break;
+            // FALLTHROUGH
+            case 9:
+              $rest = $fmtty__0[3];
+              $ty2 = $fmtty__0[2];
+              $ty1 = $fmtty__0[1];
+              $am = $call1($CamlinternalFormat[22], $ty1);
+              $ty = $call2($CamlinternalFormat[23], $am, $ty2);
+              $fmtty__10 = $call2($CamlinternalFormatBasics[1], $ty, $rest);
+              $fmtty__0 = $fmtty__10;
+              $continue_label = "switch";break;
+            // FALLTHROUGH
+            case 10:
+              $fmtty__11 = $fmtty__0[1];
+              $fmtty__0 = $fmtty__11;
+              $continue_label = "switch";break;
+            // FALLTHROUGH
+            case 11:
+              $fmtty__12 = $fmtty__0[1];
+              $fmtty__0 = $fmtty__12;
+              $continue_label = "switch";break;
+            // FALLTHROUGH
+            case 12:
+              $fmtty__13 = $fmtty__0[1];
+              $fmtty__0 = $fmtty__13;
+              $continue_label = "switch";break;
+            // FALLTHROUGH
+            case 13:
+              $fmt_rest = $fmtty__0[1];
+              return function(dynamic $reader) use ($call1,$fmt,$fmt_rest,$k,$take_fmtty_format_readers) {
+                $new_k = function(dynamic $readers_rest) use ($call1,$k,$reader) {
+                  return $call1($k, Vector{0, $reader, $readers_rest});
+                };
+                return $take_fmtty_format_readers->contents(
+                  $new_k,
+                  $fmt_rest,
+                  $fmt
+                );
+              };
+            // FALLTHROUGH
+            default:
+              $fmt_rest__0 = $fmtty__0[1];
+              return function(dynamic $reader) use ($call1,$fmt,$fmt_rest__0,$k,$take_fmtty_format_readers) {
+                $new_k = function(dynamic $readers_rest) use ($call1,$k,$reader) {
+                  return $call1($k, Vector{0, $reader, $readers_rest});
+                };
+                return $take_fmtty_format_readers->contents(
+                  $new_k,
+                  $fmt_rest__0,
+                  $fmt
+                );
+              };
+            }
+          if ($continue_label === "switch") {continue;}
         }
       }
     };
@@ -1877,472 +1961,493 @@ final class Scanf {
     $make_scanf->contents = function
     (dynamic $ib, dynamic $fmt, dynamic $readers) use ($Assert_failure,$CamlinternalFormat,$CamlinternalFormatBasics,$Failure,$Pervasives,$String,$bad_input,$call1,$call2,$caml_wrap_exception,$check_char,$checked_peek_char,$cst_end_of_input_not_found,$cst_scanf_bad_conversion_a,$cst_scanf_bad_conversion_custom_converter,$cst_scanf_bad_conversion_t,$cst_scanf_missing_reader,$end_of_input,$get_counter,$integer_conversion_of_char,$is_int,$make_scanf,$pad_prec_scanf,$q,$r,$runtime,$s,$scan_bool,$scan_caml_char,$scan_caml_float,$scan_caml_string,$scan_char,$scan_chars_in_char_set,$scan_float,$scan_hex_float,$scan_int_conversion,$scan_string,$stopper_of_formatting_lit,$token_bool,$token_char,$token_float,$token_int,$token_int32,$token_int64,$token_nativeint,$token_string,$width_of_pad_opt) {
       $fmt__0 = $fmt;
-      for (;;) if (
-        $is_int($fmt__0)
-      ) {return 0;}
-      else {
-        if ($fmt__0[0] === 0) {
-          $rest = $fmt__0[1];
-          $scan_char(0, $ib);
-          $c = $token_char($ib);
-          return Vector{0, $c, $make_scanf->contents($ib, $rest, $readers)};
-        }
-        else if ($fmt__0[0] === 1) {
-          $rest__0 = $fmt__0[1];
-          $scan_caml_char(0, $ib);
-          $c__0 = $token_char($ib);
-          return Vector{
-            0,
-            $c__0,
-            $make_scanf->contents($ib, $rest__0, $readers)
-          };
-        }
-        else if ($fmt__0[0] === 2) {
-          $K = $fmt__0[2];
-          $L = $fmt__0[1];
-          if (! $is_int($K)) {
-            switch($K[0]) {
-              // FALLTHROUGH
-              case 17:
-                $rest__1 = $K[2];
-                $fmting_lit = $K[1];
-                $match = $stopper_of_formatting_lit($fmting_lit);
-                $str = $match[2];
-                $stp = $match[1];
-                $scan__0 = function
-                (dynamic $width, dynamic $param, dynamic $ib) use ($scan_string,$stp) {
-                  return $scan_string(Vector{0, $stp}, $width, $ib);
-                };
-                $str_rest = Vector{11, $str, $rest__1};
-                return $pad_prec_scanf(
-                  $ib,
-                  $str_rest,
-                  $readers,
-                  $L,
-                  0,
-                  $scan__0,
-                  $token_string
-                );
-              // FALLTHROUGH
-              case 18:
-                $M = $K[1];
-                if (0 === $M[0]) {
-                  $rest__2 = $K[2];
-                  $match__0 = $M[1];
-                  $fmt__1 = $match__0[1];
-                  $scan__1 = function
-                  (dynamic $width, dynamic $param, dynamic $ib) use ($q,$scan_string) {
-                    return $scan_string($q, $width, $ib);
-                  };
-                  return $pad_prec_scanf(
-                    $ib,
-                    $call2($CamlinternalFormatBasics[3], $fmt__1, $rest__2),
-                    $readers,
-                    $L,
-                    0,
-                    $scan__1,
-                    $token_string
-                  );
+      for (;;) {
+        if ($is_int($fmt__0)) {return 0;}
+        else {
+          $continue_label = null;
+          switch($fmt__0[0]) {
+            // FALLTHROUGH
+            case 0:
+              $rest = $fmt__0[1];
+              $scan_char(0, $ib);
+              $c = $token_char($ib);
+              return Vector{0, $c, $make_scanf->contents($ib, $rest, $readers)
+              };
+            // FALLTHROUGH
+            case 1:
+              $rest__0 = $fmt__0[1];
+              $scan_caml_char(0, $ib);
+              $c__0 = $token_char($ib);
+              return Vector{
+                0,
+                $c__0,
+                $make_scanf->contents($ib, $rest__0, $readers)
+              };
+            // FALLTHROUGH
+            case 2:
+              $K = $fmt__0[2];
+              $L = $fmt__0[1];
+              if (! $is_int($K)) {
+                switch($K[0]) {
+                  // FALLTHROUGH
+                  case 17:
+                    $rest__1 = $K[2];
+                    $fmting_lit = $K[1];
+                    $match = $stopper_of_formatting_lit($fmting_lit);
+                    $str = $match[2];
+                    $stp = $match[1];
+                    $scan__0 = function
+                    (dynamic $width, dynamic $param, dynamic $ib) use ($scan_string,$stp) {
+                      return $scan_string(Vector{0, $stp}, $width, $ib);
+                    };
+                    $str_rest = Vector{11, $str, $rest__1};
+                    return $pad_prec_scanf(
+                      $ib,
+                      $str_rest,
+                      $readers,
+                      $L,
+                      0,
+                      $scan__0,
+                      $token_string
+                    );
+                  // FALLTHROUGH
+                  case 18:
+                    $M = $K[1];
+                    if (0 === $M[0]) {
+                      $rest__2 = $K[2];
+                      $match__0 = $M[1];
+                      $fmt__1 = $match__0[1];
+                      $scan__1 = function
+                      (dynamic $width, dynamic $param, dynamic $ib) use ($q,$scan_string) {
+                        return $scan_string($q, $width, $ib);
+                      };
+                      return $pad_prec_scanf(
+                        $ib,
+                        $call2($CamlinternalFormatBasics[3], $fmt__1, $rest__2),
+                        $readers,
+                        $L,
+                        0,
+                        $scan__1,
+                        $token_string
+                      );
+                    }
+                    $rest__3 = $K[2];
+                    $match__1 = $M[1];
+                    $fmt__2 = $match__1[1];
+                    $scan__2 = function
+                    (dynamic $width, dynamic $param, dynamic $ib) use ($r,$scan_string) {
+                      return $scan_string($r, $width, $ib);
+                    };
+                    return $pad_prec_scanf(
+                      $ib,
+                      $call2($CamlinternalFormatBasics[3], $fmt__2, $rest__3),
+                      $readers,
+                      $L,
+                      0,
+                      $scan__2,
+                      $token_string
+                    );
+                  }
+              }
+              $scan = function(dynamic $width, dynamic $param, dynamic $ib) use ($scan_string) {
+                return $scan_string(0, $width, $ib);
+              };
+              return $pad_prec_scanf(
+                $ib,
+                $K,
+                $readers,
+                $L,
+                0,
+                $scan,
+                $token_string
+              );
+            // FALLTHROUGH
+            case 3:
+              $rest__4 = $fmt__0[2];
+              $pad = $fmt__0[1];
+              $scan__3 = function(dynamic $width, dynamic $param, dynamic $ib) use ($scan_caml_string) {
+                return $scan_caml_string($width, $ib);
+              };
+              return $pad_prec_scanf(
+                $ib,
+                $rest__4,
+                $readers,
+                $pad,
+                0,
+                $scan__3,
+                $token_string
+              );
+            // FALLTHROUGH
+            case 4:
+              $rest__5 = $fmt__0[4];
+              $prec = $fmt__0[3];
+              $pad__0 = $fmt__0[2];
+              $iconv = $fmt__0[1];
+              $c__1 = $integer_conversion_of_char(
+                $call1($CamlinternalFormat[16], $iconv)
+              );
+              $scan__4 = function(dynamic $width, dynamic $param, dynamic $ib) use ($c__1,$scan_int_conversion) {
+                return $scan_int_conversion($c__1, $width, $ib);
+              };
+              return $pad_prec_scanf(
+                $ib,
+                $rest__5,
+                $readers,
+                $pad__0,
+                $prec,
+                $scan__4,
+                function(dynamic $ak) use ($c__1,$token_int) {
+                  return $token_int($c__1, $ak);
                 }
-                $rest__3 = $K[2];
-                $match__1 = $M[1];
-                $fmt__2 = $match__1[1];
-                $scan__2 = function
-                (dynamic $width, dynamic $param, dynamic $ib) use ($r,$scan_string) {
-                  return $scan_string($r, $width, $ib);
-                };
+              );
+            // FALLTHROUGH
+            case 5:
+              $rest__6 = $fmt__0[4];
+              $prec__0 = $fmt__0[3];
+              $pad__1 = $fmt__0[2];
+              $iconv__0 = $fmt__0[1];
+              $c__2 = $integer_conversion_of_char(
+                $call1($CamlinternalFormat[16], $iconv__0)
+              );
+              $scan__5 = function(dynamic $width, dynamic $param, dynamic $ib) use ($c__2,$scan_int_conversion) {
+                return $scan_int_conversion($c__2, $width, $ib);
+              };
+              return $pad_prec_scanf(
+                $ib,
+                $rest__6,
+                $readers,
+                $pad__1,
+                $prec__0,
+                $scan__5,
+                function(dynamic $aj) use ($c__2,$token_int32) {
+                  return $token_int32($c__2, $aj);
+                }
+              );
+            // FALLTHROUGH
+            case 6:
+              $rest__7 = $fmt__0[4];
+              $prec__1 = $fmt__0[3];
+              $pad__2 = $fmt__0[2];
+              $iconv__1 = $fmt__0[1];
+              $c__3 = $integer_conversion_of_char(
+                $call1($CamlinternalFormat[16], $iconv__1)
+              );
+              $scan__6 = function(dynamic $width, dynamic $param, dynamic $ib) use ($c__3,$scan_int_conversion) {
+                return $scan_int_conversion($c__3, $width, $ib);
+              };
+              return $pad_prec_scanf(
+                $ib,
+                $rest__7,
+                $readers,
+                $pad__2,
+                $prec__1,
+                $scan__6,
+                function(dynamic $ai) use ($c__3,$token_nativeint) {
+                  return $token_nativeint($c__3, $ai);
+                }
+              );
+            // FALLTHROUGH
+            case 7:
+              $rest__8 = $fmt__0[4];
+              $prec__2 = $fmt__0[3];
+              $pad__3 = $fmt__0[2];
+              $iconv__2 = $fmt__0[1];
+              $c__4 = $integer_conversion_of_char(
+                $call1($CamlinternalFormat[16], $iconv__2)
+              );
+              $scan__7 = function(dynamic $width, dynamic $param, dynamic $ib) use ($c__4,$scan_int_conversion) {
+                return $scan_int_conversion($c__4, $width, $ib);
+              };
+              return $pad_prec_scanf(
+                $ib,
+                $rest__8,
+                $readers,
+                $pad__3,
+                $prec__2,
+                $scan__7,
+                function(dynamic $ah) use ($c__4,$token_int64) {
+                  return $token_int64($c__4, $ah);
+                }
+              );
+            // FALLTHROUGH
+            case 8:
+              $N = $fmt__0[1];
+              if (15 === $N) {
+                $rest__9 = $fmt__0[4];
+                $prec__3 = $fmt__0[3];
+                $pad__4 = $fmt__0[2];
                 return $pad_prec_scanf(
                   $ib,
-                  $call2($CamlinternalFormatBasics[3], $fmt__2, $rest__3),
+                  $rest__9,
                   $readers,
-                  $L,
-                  0,
-                  $scan__2,
-                  $token_string
+                  $pad__4,
+                  $prec__3,
+                  $scan_caml_float,
+                  $token_float
                 );
               }
-          }
-          $scan = function(dynamic $width, dynamic $param, dynamic $ib) use ($scan_string) {
-            return $scan_string(0, $width, $ib);
-          };
-          return $pad_prec_scanf(
-            $ib,
-            $K,
-            $readers,
-            $L,
-            0,
-            $scan,
-            $token_string
-          );
-        }
-        else if ($fmt__0[0] === 3) {
-          $rest__4 = $fmt__0[2];
-          $pad = $fmt__0[1];
-          $scan__3 = function(dynamic $width, dynamic $param, dynamic $ib) use ($scan_caml_string) {
-            return $scan_caml_string($width, $ib);
-          };
-          return $pad_prec_scanf(
-            $ib,
-            $rest__4,
-            $readers,
-            $pad,
-            0,
-            $scan__3,
-            $token_string
-          );
-        }
-        else if ($fmt__0[0] === 4) {
-          $rest__5 = $fmt__0[4];
-          $prec = $fmt__0[3];
-          $pad__0 = $fmt__0[2];
-          $iconv = $fmt__0[1];
-          $c__1 = $integer_conversion_of_char(
-            $call1($CamlinternalFormat[16], $iconv)
-          );
-          $scan__4 = function(dynamic $width, dynamic $param, dynamic $ib) use ($c__1,$scan_int_conversion) {
-            return $scan_int_conversion($c__1, $width, $ib);
-          };
-          return $pad_prec_scanf(
-            $ib,
-            $rest__5,
-            $readers,
-            $pad__0,
-            $prec,
-            $scan__4,
-            function(dynamic $ak) use ($c__1,$token_int) {
-              return $token_int($c__1, $ak);
+              if (16 <= $N) {
+                $rest__10 = $fmt__0[4];
+                $prec__4 = $fmt__0[3];
+                $pad__5 = $fmt__0[2];
+                return $pad_prec_scanf(
+                  $ib,
+                  $rest__10,
+                  $readers,
+                  $pad__5,
+                  $prec__4,
+                  $scan_hex_float,
+                  $token_float
+                );
+              }
+              $rest__11 = $fmt__0[4];
+              $prec__5 = $fmt__0[3];
+              $pad__6 = $fmt__0[2];
+              return $pad_prec_scanf(
+                $ib,
+                $rest__11,
+                $readers,
+                $pad__6,
+                $prec__5,
+                $scan_float,
+                $token_float
+              );
+            // FALLTHROUGH
+            case 9:
+              $rest__12 = $fmt__0[2];
+              $pad__7 = $fmt__0[1];
+              $scan__8 = function(dynamic $param, dynamic $ag, dynamic $ib) use ($scan_bool) {return $scan_bool($ib);
+              };
+              return $pad_prec_scanf(
+                $ib,
+                $rest__12,
+                $readers,
+                $pad__7,
+                0,
+                $scan__8,
+                $token_bool
+              );
+            // FALLTHROUGH
+            case 10:
+              $rest__13 = $fmt__0[1];
+              if ($end_of_input($ib)) {
+                $fmt__0 = $rest__13;
+                $continue_label = "switch";break;
+              }
+              return $bad_input($cst_end_of_input_not_found);
+            // FALLTHROUGH
+            case 11:
+              $fmt__3 = $fmt__0[2];
+              $str__0 = $fmt__0[1];
+              $O = function(dynamic $af) use ($check_char,$ib) {
+                return $check_char($ib, $af);
+              };
+              $call2($String[8], $O, $str__0);
+              $fmt__0 = $fmt__3;
+              $continue_label = "switch";break;
+            // FALLTHROUGH
+            case 12:
+              $fmt__4 = $fmt__0[2];
+              $chr = $fmt__0[1];
+              $check_char($ib, $chr);
+              $fmt__0 = $fmt__4;
+              $continue_label = "switch";break;
+            // FALLTHROUGH
+            case 13:
+              $rest__14 = $fmt__0[3];
+              $fmtty = $fmt__0[2];
+              $pad_opt = $fmt__0[1];
+              $scan_caml_string($width_of_pad_opt($pad_opt), $ib);
+              $s__0 = $token_string($ib);
+              try {
+                $Q = $call2($CamlinternalFormat[14], $s__0, $fmtty);
+                $fmt__5 = $Q;
+              }
+              catch(\Throwable $exn) {
+                $exn = $caml_wrap_exception($exn);
+                if ($exn[1] !== $Failure) {
+                  throw $runtime["caml_wrap_thrown_exception_reraise"]($exn) as \Throwable;
+                }
+                $msg = $exn[2];
+                $P = $bad_input($msg);
+                $fmt__5 = $P;
+              }
+              return Vector{
+                0,
+                $fmt__5,
+                $make_scanf->contents($ib, $rest__14, $readers)
+              };
+            // FALLTHROUGH
+            case 14:
+              $rest__15 = $fmt__0[3];
+              $fmtty__0 = $fmt__0[2];
+              $pad_opt__0 = $fmt__0[1];
+              $scan_caml_string($width_of_pad_opt($pad_opt__0), $ib);
+              $s__1 = $token_string($ib);
+              try {
+                $match__2 = $call2($CamlinternalFormat[13], 0, $s__1);
+                $fmt__8 = $match__2[1];
+                $match__3 = $call2($CamlinternalFormat[13], 0, $s__1);
+                $fmt__9 = $match__3[1];
+                $U = $call1($CamlinternalFormat[22], $fmtty__0);
+                $V = $call1($CamlinternalFormatBasics[2], $U);
+                $fmt__10 = $call2($CamlinternalFormat[12], $fmt__9, $V);
+                $W = $call1($CamlinternalFormatBasics[2], $fmtty__0);
+                $X = $call2($CamlinternalFormat[12], $fmt__8, $W);
+                $fmt__7 = $X;
+                $fmt__6 = $fmt__10;
+              }
+              catch(\Throwable $exn) {
+                $exn = $caml_wrap_exception($exn);
+                if ($exn[1] !== $Failure) {
+                  throw $runtime["caml_wrap_thrown_exception_reraise"]($exn) as \Throwable;
+                }
+                $msg__0 = $exn[2];
+                $R = $bad_input($msg__0);
+                $S = $R[2];
+                $T = $R[1];
+                $fmt__7 = $T;
+                $fmt__6 = $S;
+              }
+              return Vector{
+                0,
+                Vector{0, $fmt__7, $s__1},
+                $make_scanf->contents(
+                  $ib,
+                  $call2($CamlinternalFormatBasics[3], $fmt__6, $rest__15),
+                  $readers
+                )
+              };
+            // FALLTHROUGH
+            case 15:
+              return $call1($Pervasives[1], $cst_scanf_bad_conversion_a);
+            // FALLTHROUGH
+            case 16:
+              return $call1($Pervasives[1], $cst_scanf_bad_conversion_t);
+            // FALLTHROUGH
+            case 17:
+              $fmt__11 = $fmt__0[2];
+              $formatting_lit = $fmt__0[1];
+              $Y = $call1($CamlinternalFormat[17], $formatting_lit);
+              $Z = function(dynamic $ae) use ($check_char,$ib) {
+                return $check_char($ib, $ae);
+              };
+              $call2($String[8], $Z, $Y);
+              $fmt__0 = $fmt__11;
+              $continue_label = "switch";break;
+            // FALLTHROUGH
+            case 18:
+              $aa = $fmt__0[1];
+              if (0 === $aa[0]) {
+                $rest__16 = $fmt__0[2];
+                $match__4 = $aa[1];
+                $fmt__12 = $match__4[1];
+                $check_char($ib, 64);
+                $check_char($ib, 123);
+                $fmt__13 = $call2(
+                  $CamlinternalFormatBasics[3],
+                  $fmt__12,
+                  $rest__16
+                );
+                $fmt__0 = $fmt__13;
+                $continue_label = "switch";break;
+              }
+              $rest__17 = $fmt__0[2];
+              $match__5 = $aa[1];
+              $fmt__14 = $match__5[1];
+              $check_char($ib, 64);
+              $check_char($ib, 91);
+              $fmt__15 = $call2(
+                $CamlinternalFormatBasics[3],
+                $fmt__14,
+                $rest__17
+              );
+              $fmt__0 = $fmt__15;
+              $continue_label = "switch";break;
+            // FALLTHROUGH
+            case 19:
+              $fmt_rest = $fmt__0[1];
+              if ($readers) {
+                $readers_rest = $readers[2];
+                $reader = $readers[1];
+                $x = $call1($reader, $ib);
+                return Vector{
+                  0,
+                  $x,
+                  $make_scanf->contents($ib, $fmt_rest, $readers_rest)
+                };
+              }
+              return $call1($Pervasives[1], $cst_scanf_missing_reader);
+            // FALLTHROUGH
+            case 20:
+              $ab = $fmt__0[3];
+              $ac = $fmt__0[2];
+              $ad = $fmt__0[1];
+              if (! $is_int($ab) && 17 === $ab[0]) {
+                $rest__18 = $ab[2];
+                $fmting_lit__0 = $ab[1];
+                $match__6 = $stopper_of_formatting_lit($fmting_lit__0);
+                $str__1 = $match__6[2];
+                $stp__0 = $match__6[1];
+                $width__0 = $width_of_pad_opt($ad);
+                $scan_chars_in_char_set(
+                  $ac,
+                  Vector{0, $stp__0},
+                  $width__0,
+                  $ib
+                );
+                $s__3 = $token_string($ib);
+                $str_rest__0 = Vector{11, $str__1, $rest__18};
+                return Vector{
+                  0,
+                  $s__3,
+                  $make_scanf->contents($ib, $str_rest__0, $readers)
+                };
+              }
+              $width = $width_of_pad_opt($ad);
+              $scan_chars_in_char_set($ac, 0, $width, $ib);
+              $s__2 = $token_string($ib);
+              return Vector{
+                0,
+                $s__2,
+                $make_scanf->contents($ib, $ab, $readers)
+              };
+            // FALLTHROUGH
+            case 21:
+              $rest__19 = $fmt__0[2];
+              $counter = $fmt__0[1];
+              $count = $get_counter($ib, $counter);
+              return Vector{
+                0,
+                $count,
+                $make_scanf->contents($ib, $rest__19, $readers)
+              };
+            // FALLTHROUGH
+            case 22:
+              $rest__20 = $fmt__0[1];
+              $c__5 = $checked_peek_char($ib);
+              return Vector{
+                0,
+                $c__5,
+                $make_scanf->contents($ib, $rest__20, $readers)
+              };
+            // FALLTHROUGH
+            case 23:
+              $rest__21 = $fmt__0[2];
+              $ign = $fmt__0[1];
+              $match__7 = $call2($CamlinternalFormat[6], $ign, $rest__21);
+              $fmt__16 = $match__7[1];
+              $match__8 = $make_scanf->contents($ib, $fmt__16, $readers);
+              if ($match__8) {$arg_rest = $match__8[2];return $arg_rest;}
+              throw $runtime["caml_wrap_thrown_exception"](Vector{0, $Assert_failure, $s}) as \Throwable;
+            // FALLTHROUGH
+            default:
+              return $call1(
+                $Pervasives[1],
+                $cst_scanf_bad_conversion_custom_converter
+              );
             }
-          );
-        }
-        else if ($fmt__0[0] === 5) {
-          $rest__6 = $fmt__0[4];
-          $prec__0 = $fmt__0[3];
-          $pad__1 = $fmt__0[2];
-          $iconv__0 = $fmt__0[1];
-          $c__2 = $integer_conversion_of_char(
-            $call1($CamlinternalFormat[16], $iconv__0)
-          );
-          $scan__5 = function(dynamic $width, dynamic $param, dynamic $ib) use ($c__2,$scan_int_conversion) {
-            return $scan_int_conversion($c__2, $width, $ib);
-          };
-          return $pad_prec_scanf(
-            $ib,
-            $rest__6,
-            $readers,
-            $pad__1,
-            $prec__0,
-            $scan__5,
-            function(dynamic $aj) use ($c__2,$token_int32) {
-              return $token_int32($c__2, $aj);
-            }
-          );
-        }
-        else if ($fmt__0[0] === 6) {
-          $rest__7 = $fmt__0[4];
-          $prec__1 = $fmt__0[3];
-          $pad__2 = $fmt__0[2];
-          $iconv__1 = $fmt__0[1];
-          $c__3 = $integer_conversion_of_char(
-            $call1($CamlinternalFormat[16], $iconv__1)
-          );
-          $scan__6 = function(dynamic $width, dynamic $param, dynamic $ib) use ($c__3,$scan_int_conversion) {
-            return $scan_int_conversion($c__3, $width, $ib);
-          };
-          return $pad_prec_scanf(
-            $ib,
-            $rest__7,
-            $readers,
-            $pad__2,
-            $prec__1,
-            $scan__6,
-            function(dynamic $ai) use ($c__3,$token_nativeint) {
-              return $token_nativeint($c__3, $ai);
-            }
-          );
-        }
-        else if ($fmt__0[0] === 7) {
-          $rest__8 = $fmt__0[4];
-          $prec__2 = $fmt__0[3];
-          $pad__3 = $fmt__0[2];
-          $iconv__2 = $fmt__0[1];
-          $c__4 = $integer_conversion_of_char(
-            $call1($CamlinternalFormat[16], $iconv__2)
-          );
-          $scan__7 = function(dynamic $width, dynamic $param, dynamic $ib) use ($c__4,$scan_int_conversion) {
-            return $scan_int_conversion($c__4, $width, $ib);
-          };
-          return $pad_prec_scanf(
-            $ib,
-            $rest__8,
-            $readers,
-            $pad__3,
-            $prec__2,
-            $scan__7,
-            function(dynamic $ah) use ($c__4,$token_int64) {
-              return $token_int64($c__4, $ah);
-            }
-          );
-        }
-        else if ($fmt__0[0] === 8) {
-          $N = $fmt__0[1];
-          if (15 === $N) {
-            $rest__9 = $fmt__0[4];
-            $prec__3 = $fmt__0[3];
-            $pad__4 = $fmt__0[2];
-            return $pad_prec_scanf(
-              $ib,
-              $rest__9,
-              $readers,
-              $pad__4,
-              $prec__3,
-              $scan_caml_float,
-              $token_float
-            );
-          }
-          if (16 <= $N) {
-            $rest__10 = $fmt__0[4];
-            $prec__4 = $fmt__0[3];
-            $pad__5 = $fmt__0[2];
-            return $pad_prec_scanf(
-              $ib,
-              $rest__10,
-              $readers,
-              $pad__5,
-              $prec__4,
-              $scan_hex_float,
-              $token_float
-            );
-          }
-          $rest__11 = $fmt__0[4];
-          $prec__5 = $fmt__0[3];
-          $pad__6 = $fmt__0[2];
-          return $pad_prec_scanf(
-            $ib,
-            $rest__11,
-            $readers,
-            $pad__6,
-            $prec__5,
-            $scan_float,
-            $token_float
-          );
-        }
-        else if ($fmt__0[0] === 9) {
-          $rest__12 = $fmt__0[2];
-          $pad__7 = $fmt__0[1];
-          $scan__8 = function(dynamic $param, dynamic $ag, dynamic $ib) use ($scan_bool) {return $scan_bool($ib);
-          };
-          return $pad_prec_scanf(
-            $ib,
-            $rest__12,
-            $readers,
-            $pad__7,
-            0,
-            $scan__8,
-            $token_bool
-          );
-        }
-        else if ($fmt__0[0] === 10) {
-          $rest__13 = $fmt__0[1];
-          if ($end_of_input($ib)) {$fmt__0 = $rest__13;continue;}
-          return $bad_input($cst_end_of_input_not_found);
-        }
-        else if ($fmt__0[0] === 11) {
-          $fmt__3 = $fmt__0[2];
-          $str__0 = $fmt__0[1];
-          $O = function(dynamic $af) use ($check_char,$ib) {
-            return $check_char($ib, $af);
-          };
-          $call2($String[8], $O, $str__0);
-          $fmt__0 = $fmt__3;
-          continue;
-        }
-        else if ($fmt__0[0] === 12) {
-          $fmt__4 = $fmt__0[2];
-          $chr = $fmt__0[1];
-          $check_char($ib, $chr);
-          $fmt__0 = $fmt__4;
-          continue;
-        }
-        else if ($fmt__0[0] === 13) {
-          $rest__14 = $fmt__0[3];
-          $fmtty = $fmt__0[2];
-          $pad_opt = $fmt__0[1];
-          $scan_caml_string($width_of_pad_opt($pad_opt), $ib);
-          $s__0 = $token_string($ib);
-          try {
-            $Q = $call2($CamlinternalFormat[14], $s__0, $fmtty);
-            $fmt__5 = $Q;
-          }
-          catch(\Throwable $exn) {
-            $exn = $caml_wrap_exception($exn);
-            if ($exn[1] !== $Failure) {
-              throw $runtime["caml_wrap_thrown_exception_reraise"]($exn) as \Throwable;
-            }
-            $msg = $exn[2];
-            $P = $bad_input($msg);
-            $fmt__5 = $P;
-          }
-          return Vector{
-            0,
-            $fmt__5,
-            $make_scanf->contents($ib, $rest__14, $readers)
-          };
-        }
-        else if ($fmt__0[0] === 14) {
-          $rest__15 = $fmt__0[3];
-          $fmtty__0 = $fmt__0[2];
-          $pad_opt__0 = $fmt__0[1];
-          $scan_caml_string($width_of_pad_opt($pad_opt__0), $ib);
-          $s__1 = $token_string($ib);
-          try {
-            $match__2 = $call2($CamlinternalFormat[13], 0, $s__1);
-            $fmt__8 = $match__2[1];
-            $match__3 = $call2($CamlinternalFormat[13], 0, $s__1);
-            $fmt__9 = $match__3[1];
-            $U = $call1($CamlinternalFormat[22], $fmtty__0);
-            $V = $call1($CamlinternalFormatBasics[2], $U);
-            $fmt__10 = $call2($CamlinternalFormat[12], $fmt__9, $V);
-            $W = $call1($CamlinternalFormatBasics[2], $fmtty__0);
-            $X = $call2($CamlinternalFormat[12], $fmt__8, $W);
-            $fmt__7 = $X;
-            $fmt__6 = $fmt__10;
-          }
-          catch(\Throwable $exn) {
-            $exn = $caml_wrap_exception($exn);
-            if ($exn[1] !== $Failure) {
-              throw $runtime["caml_wrap_thrown_exception_reraise"]($exn) as \Throwable;
-            }
-            $msg__0 = $exn[2];
-            $R = $bad_input($msg__0);
-            $S = $R[2];
-            $T = $R[1];
-            $fmt__7 = $T;
-            $fmt__6 = $S;
-          }
-          return Vector{
-            0,
-            Vector{0, $fmt__7, $s__1},
-            $make_scanf->contents(
-              $ib,
-              $call2($CamlinternalFormatBasics[3], $fmt__6, $rest__15),
-              $readers
-            )
-          };
-        }
-        else if ($fmt__0[0] === 15) {
-          return $call1($Pervasives[1], $cst_scanf_bad_conversion_a);
-        }
-        else if ($fmt__0[0] === 16) {
-          return $call1($Pervasives[1], $cst_scanf_bad_conversion_t);
-        }
-        else if ($fmt__0[0] === 17) {
-          $fmt__11 = $fmt__0[2];
-          $formatting_lit = $fmt__0[1];
-          $Y = $call1($CamlinternalFormat[17], $formatting_lit);
-          $Z = function(dynamic $ae) use ($check_char,$ib) {
-            return $check_char($ib, $ae);
-          };
-          $call2($String[8], $Z, $Y);
-          $fmt__0 = $fmt__11;
-          continue;
-        }
-        else if ($fmt__0[0] === 18) {
-          $aa = $fmt__0[1];
-          if (0 === $aa[0]) {
-            $rest__16 = $fmt__0[2];
-            $match__4 = $aa[1];
-            $fmt__12 = $match__4[1];
-            $check_char($ib, 64);
-            $check_char($ib, 123);
-            $fmt__13 = $call2(
-              $CamlinternalFormatBasics[3],
-              $fmt__12,
-              $rest__16
-            );
-            $fmt__0 = $fmt__13;
-            continue;
-          }
-          $rest__17 = $fmt__0[2];
-          $match__5 = $aa[1];
-          $fmt__14 = $match__5[1];
-          $check_char($ib, 64);
-          $check_char($ib, 91);
-          $fmt__15 = $call2($CamlinternalFormatBasics[3], $fmt__14, $rest__17);
-          $fmt__0 = $fmt__15;
-          continue;
-        }
-        else if ($fmt__0[0] === 19) {
-          $fmt_rest = $fmt__0[1];
-          if ($readers) {
-            $readers_rest = $readers[2];
-            $reader = $readers[1];
-            $x = $call1($reader, $ib);
-            return Vector{
-              0,
-              $x,
-              $make_scanf->contents($ib, $fmt_rest, $readers_rest)
-            };
-          }
-          return $call1($Pervasives[1], $cst_scanf_missing_reader);
-        }
-        else if ($fmt__0[0] === 20) {
-          $ab = $fmt__0[3];
-          $ac = $fmt__0[2];
-          $ad = $fmt__0[1];
-          if (! $is_int($ab) && 17 === $ab[0]) {
-            $rest__18 = $ab[2];
-            $fmting_lit__0 = $ab[1];
-            $match__6 = $stopper_of_formatting_lit($fmting_lit__0);
-            $str__1 = $match__6[2];
-            $stp__0 = $match__6[1];
-            $width__0 = $width_of_pad_opt($ad);
-            $scan_chars_in_char_set($ac, Vector{0, $stp__0}, $width__0, $ib);
-            $s__3 = $token_string($ib);
-            $str_rest__0 = Vector{11, $str__1, $rest__18};
-            return Vector{
-              0,
-              $s__3,
-              $make_scanf->contents($ib, $str_rest__0, $readers)
-            };
-          }
-          $width = $width_of_pad_opt($ad);
-          $scan_chars_in_char_set($ac, 0, $width, $ib);
-          $s__2 = $token_string($ib);
-          return Vector{0, $s__2, $make_scanf->contents($ib, $ab, $readers)};
-        }
-        else if ($fmt__0[0] === 21) {
-          $rest__19 = $fmt__0[2];
-          $counter = $fmt__0[1];
-          $count = $get_counter($ib, $counter);
-          return Vector{
-            0,
-            $count,
-            $make_scanf->contents($ib, $rest__19, $readers)
-          };
-        }
-        else if ($fmt__0[0] === 22) {
-          $rest__20 = $fmt__0[1];
-          $c__5 = $checked_peek_char($ib);
-          return Vector{
-            0,
-            $c__5,
-            $make_scanf->contents($ib, $rest__20, $readers)
-          };
-        }
-        else if ($fmt__0[0] === 23) {
-          $rest__21 = $fmt__0[2];
-          $ign = $fmt__0[1];
-          $match__7 = $call2($CamlinternalFormat[6], $ign, $rest__21);
-          $fmt__16 = $match__7[1];
-          $match__8 = $make_scanf->contents($ib, $fmt__16, $readers);
-          if ($match__8) {$arg_rest = $match__8[2];return $arg_rest;}
-          throw $runtime["caml_wrap_thrown_exception"](Vector{0, $Assert_failure, $s}) as \Throwable;
-        }
-        else {
-          return $call1(
-            $Pervasives[1],
-            $cst_scanf_bad_conversion_custom_converter
-          );
+          if ($continue_label === "switch") {continue;}
         }
       }
     };

--- a/rehack_tests/stdlib/stdlib.cma.php/Scanf.php
+++ b/rehack_tests/stdlib/stdlib.cma.php/Scanf.php
@@ -1438,72 +1438,72 @@ final class Scanf {
             case 0:
               $fmt__1 = $fmt__0[1];
               $fmt__0 = $fmt__1;
-              $continue_label = "switch";break;
+              $continue_label = "#";break;
             // FALLTHROUGH
             case 1:
               $fmt__2 = $fmt__0[1];
               $fmt__0 = $fmt__2;
-              $continue_label = "switch";break;
+              $continue_label = "#";break;
             // FALLTHROUGH
             case 2:
               $fmt__3 = $fmt__0[2];
               $fmt__0 = $fmt__3;
-              $continue_label = "switch";break;
+              $continue_label = "#";break;
             // FALLTHROUGH
             case 3:
               $fmt__4 = $fmt__0[2];
               $fmt__0 = $fmt__4;
-              $continue_label = "switch";break;
+              $continue_label = "#";break;
             // FALLTHROUGH
             case 4:
               $fmt__5 = $fmt__0[4];
               $fmt__0 = $fmt__5;
-              $continue_label = "switch";break;
+              $continue_label = "#";break;
             // FALLTHROUGH
             case 5:
               $fmt__6 = $fmt__0[4];
               $fmt__0 = $fmt__6;
-              $continue_label = "switch";break;
+              $continue_label = "#";break;
             // FALLTHROUGH
             case 6:
               $fmt__7 = $fmt__0[4];
               $fmt__0 = $fmt__7;
-              $continue_label = "switch";break;
+              $continue_label = "#";break;
             // FALLTHROUGH
             case 7:
               $fmt__8 = $fmt__0[4];
               $fmt__0 = $fmt__8;
-              $continue_label = "switch";break;
+              $continue_label = "#";break;
             // FALLTHROUGH
             case 8:
               $fmt__9 = $fmt__0[4];
               $fmt__0 = $fmt__9;
-              $continue_label = "switch";break;
+              $continue_label = "#";break;
             // FALLTHROUGH
             case 9:
               $fmt__10 = $fmt__0[2];
               $fmt__0 = $fmt__10;
-              $continue_label = "switch";break;
+              $continue_label = "#";break;
             // FALLTHROUGH
             case 10:
               $fmt__11 = $fmt__0[1];
               $fmt__0 = $fmt__11;
-              $continue_label = "switch";break;
+              $continue_label = "#";break;
             // FALLTHROUGH
             case 11:
               $fmt__12 = $fmt__0[2];
               $fmt__0 = $fmt__12;
-              $continue_label = "switch";break;
+              $continue_label = "#";break;
             // FALLTHROUGH
             case 12:
               $fmt__13 = $fmt__0[2];
               $fmt__0 = $fmt__13;
-              $continue_label = "switch";break;
+              $continue_label = "#";break;
             // FALLTHROUGH
             case 13:
               $fmt__14 = $fmt__0[3];
               $fmt__0 = $fmt__14;
-              $continue_label = "switch";break;
+              $continue_label = "#";break;
             // FALLTHROUGH
             case 14:
               $rest = $fmt__0[3];
@@ -1527,17 +1527,17 @@ final class Scanf {
             case 15:
               $fmt__15 = $fmt__0[1];
               $fmt__0 = $fmt__15;
-              $continue_label = "switch";break;
+              $continue_label = "#";break;
             // FALLTHROUGH
             case 16:
               $fmt__16 = $fmt__0[1];
               $fmt__0 = $fmt__16;
-              $continue_label = "switch";break;
+              $continue_label = "#";break;
             // FALLTHROUGH
             case 17:
               $fmt__17 = $fmt__0[2];
               $fmt__0 = $fmt__17;
-              $continue_label = "switch";break;
+              $continue_label = "#";break;
             // FALLTHROUGH
             case 18:
               $ap = $fmt__0[1];
@@ -1551,7 +1551,7 @@ final class Scanf {
                   $rest__0
                 );
                 $fmt__0 = $fmt__19;
-                $continue_label = "switch";break;
+                $continue_label = "#";break;
               }
               $rest__1 = $fmt__0[2];
               $match__0 = $ap[1];
@@ -1562,7 +1562,7 @@ final class Scanf {
                 $rest__1
               );
               $fmt__0 = $fmt__21;
-              $continue_label = "switch";break;
+              $continue_label = "#";break;
             // FALLTHROUGH
             case 19:
               $fmt_rest = $fmt__0[1];
@@ -1576,17 +1576,17 @@ final class Scanf {
             case 20:
               $fmt__22 = $fmt__0[3];
               $fmt__0 = $fmt__22;
-              $continue_label = "switch";break;
+              $continue_label = "#";break;
             // FALLTHROUGH
             case 21:
               $fmt__23 = $fmt__0[2];
               $fmt__0 = $fmt__23;
-              $continue_label = "switch";break;
+              $continue_label = "#";break;
             // FALLTHROUGH
             case 22:
               $fmt__24 = $fmt__0[1];
               $fmt__0 = $fmt__24;
-              $continue_label = "switch";break;
+              $continue_label = "#";break;
             // FALLTHROUGH
             case 23:
               $rest__2 = $fmt__0[2];
@@ -1608,9 +1608,9 @@ final class Scanf {
             default:
               $fmt__25 = $fmt__0[3];
               $fmt__0 = $fmt__25;
-              $continue_label = "switch";break;
+              $continue_label = "#";break;
             }
-          if ($continue_label === "switch") {continue;}
+          if ($continue_label === "#") {continue;}
         }
       }
     };
@@ -1635,47 +1635,47 @@ final class Scanf {
             case 0:
               $fmtty__1 = $fmtty__0[1];
               $fmtty__0 = $fmtty__1;
-              $continue_label = "switch";break;
+              $continue_label = "#";break;
             // FALLTHROUGH
             case 1:
               $fmtty__2 = $fmtty__0[1];
               $fmtty__0 = $fmtty__2;
-              $continue_label = "switch";break;
+              $continue_label = "#";break;
             // FALLTHROUGH
             case 2:
               $fmtty__3 = $fmtty__0[1];
               $fmtty__0 = $fmtty__3;
-              $continue_label = "switch";break;
+              $continue_label = "#";break;
             // FALLTHROUGH
             case 3:
               $fmtty__4 = $fmtty__0[1];
               $fmtty__0 = $fmtty__4;
-              $continue_label = "switch";break;
+              $continue_label = "#";break;
             // FALLTHROUGH
             case 4:
               $fmtty__5 = $fmtty__0[1];
               $fmtty__0 = $fmtty__5;
-              $continue_label = "switch";break;
+              $continue_label = "#";break;
             // FALLTHROUGH
             case 5:
               $fmtty__6 = $fmtty__0[1];
               $fmtty__0 = $fmtty__6;
-              $continue_label = "switch";break;
+              $continue_label = "#";break;
             // FALLTHROUGH
             case 6:
               $fmtty__7 = $fmtty__0[1];
               $fmtty__0 = $fmtty__7;
-              $continue_label = "switch";break;
+              $continue_label = "#";break;
             // FALLTHROUGH
             case 7:
               $fmtty__8 = $fmtty__0[1];
               $fmtty__0 = $fmtty__8;
-              $continue_label = "switch";break;
+              $continue_label = "#";break;
             // FALLTHROUGH
             case 8:
               $fmtty__9 = $fmtty__0[2];
               $fmtty__0 = $fmtty__9;
-              $continue_label = "switch";break;
+              $continue_label = "#";break;
             // FALLTHROUGH
             case 9:
               $rest = $fmtty__0[3];
@@ -1685,22 +1685,22 @@ final class Scanf {
               $ty = $call2($CamlinternalFormat[23], $am, $ty2);
               $fmtty__10 = $call2($CamlinternalFormatBasics[1], $ty, $rest);
               $fmtty__0 = $fmtty__10;
-              $continue_label = "switch";break;
+              $continue_label = "#";break;
             // FALLTHROUGH
             case 10:
               $fmtty__11 = $fmtty__0[1];
               $fmtty__0 = $fmtty__11;
-              $continue_label = "switch";break;
+              $continue_label = "#";break;
             // FALLTHROUGH
             case 11:
               $fmtty__12 = $fmtty__0[1];
               $fmtty__0 = $fmtty__12;
-              $continue_label = "switch";break;
+              $continue_label = "#";break;
             // FALLTHROUGH
             case 12:
               $fmtty__13 = $fmtty__0[1];
               $fmtty__0 = $fmtty__13;
-              $continue_label = "switch";break;
+              $continue_label = "#";break;
             // FALLTHROUGH
             case 13:
               $fmt_rest = $fmtty__0[1];
@@ -1728,7 +1728,7 @@ final class Scanf {
                 );
               };
             }
-          if ($continue_label === "switch") {continue;}
+          if ($continue_label === "#") {continue;}
         }
       }
     };
@@ -2232,7 +2232,7 @@ final class Scanf {
               $rest__13 = $fmt__0[1];
               if ($end_of_input($ib)) {
                 $fmt__0 = $rest__13;
-                $continue_label = "switch";break;
+                $continue_label = "#";break;
               }
               return $bad_input($cst_end_of_input_not_found);
             // FALLTHROUGH
@@ -2244,14 +2244,14 @@ final class Scanf {
               };
               $call2($String[8], $O, $str__0);
               $fmt__0 = $fmt__3;
-              $continue_label = "switch";break;
+              $continue_label = "#";break;
             // FALLTHROUGH
             case 12:
               $fmt__4 = $fmt__0[2];
               $chr = $fmt__0[1];
               $check_char($ib, $chr);
               $fmt__0 = $fmt__4;
-              $continue_label = "switch";break;
+              $continue_label = "#";break;
             // FALLTHROUGH
             case 13:
               $rest__14 = $fmt__0[3];
@@ -2334,7 +2334,7 @@ final class Scanf {
               };
               $call2($String[8], $Z, $Y);
               $fmt__0 = $fmt__11;
-              $continue_label = "switch";break;
+              $continue_label = "#";break;
             // FALLTHROUGH
             case 18:
               $aa = $fmt__0[1];
@@ -2350,7 +2350,7 @@ final class Scanf {
                   $rest__16
                 );
                 $fmt__0 = $fmt__13;
-                $continue_label = "switch";break;
+                $continue_label = "#";break;
               }
               $rest__17 = $fmt__0[2];
               $match__5 = $aa[1];
@@ -2363,7 +2363,7 @@ final class Scanf {
                 $rest__17
               );
               $fmt__0 = $fmt__15;
-              $continue_label = "switch";break;
+              $continue_label = "#";break;
             // FALLTHROUGH
             case 19:
               $fmt_rest = $fmt__0[1];
@@ -2447,7 +2447,7 @@ final class Scanf {
                 $cst_scanf_bad_conversion_custom_converter
               );
             }
-          if ($continue_label === "switch") {continue;}
+          if ($continue_label === "#") {continue;}
         }
       }
     };

--- a/rehack_tests/stdlib/stdlib.cma.php/Sort.php
+++ b/rehack_tests/stdlib/stdlib.cma.php/Sort.php
@@ -110,8 +110,8 @@ final class Sort {
       $qsort->contents = function(dynamic $lo, dynamic $hi) use ($Invalid_argument,$arr,$call2,$cmp,$cst_Sort_array,$qsort,$runtime,$swap,$unsigned_right_shift_32) {
         $lo__0 = $lo;
         $hi__0 = $hi;
-        $continue_label = null;
         for (;;) {
+          $continue_label = null;
           $d = 6 <= (int) ($hi__0 - $lo__0) ? 1 : (0);
           if ($d) {
             $mid = (int) $unsigned_right_shift_32((int) ($lo__0 + $hi__0), 1);
@@ -130,8 +130,8 @@ final class Sort {
                       Vector{0, $Invalid_argument, $cst_Sort_array}
                     ) as \Throwable;
             }
-            $continue_label = null;
             for (;;) {
+              $continue_label = null;
               if ($i[1] < $j[1]) {
                 for (;;) {
                   if ($call2($cmp, $pivot, $arr[$i[1] + 1])) {
@@ -151,7 +151,6 @@ final class Sort {
                   continue;
                 }
                 if ($continue_label === "b") {continue;}
-                else if ($continue_label !== null) {break;}
               }
               if ((int) ($j[1] - $lo__0) <= (int) ($hi__0 - $i[1])) {
                 $qsort->contents($lo__0, $j[1]);
@@ -165,7 +164,6 @@ final class Sort {
               $continue_label = "a";break;
             }
             if ($continue_label === "a") {continue;}
-            else if ($continue_label !== null) {break;}
           }
           return $d;
         }

--- a/rehack_tests/stdlib/stdlib.cma.php/Sort.php
+++ b/rehack_tests/stdlib/stdlib.cma.php/Sort.php
@@ -110,7 +110,7 @@ final class Sort {
       $qsort->contents = function(dynamic $lo, dynamic $hi) use ($Invalid_argument,$arr,$call2,$cmp,$cst_Sort_array,$qsort,$runtime,$swap,$unsigned_right_shift_32) {
         $lo__0 = $lo;
         $hi__0 = $hi;
-        $continue_counter = null;
+        $continue_label = null;
         for (;;) {
           $d = 6 <= (int) ($hi__0 - $lo__0) ? 1 : (0);
           if ($d) {
@@ -130,6 +130,7 @@ final class Sort {
                       Vector{0, $Invalid_argument, $cst_Sort_array}
                     ) as \Throwable;
             }
+            $continue_label = null;
             for (;;) {
               if ($i[1] < $j[1]) {
                 for (;;) {
@@ -139,51 +140,32 @@ final class Sort {
                         if ($i[1] < $j[1]) {$swap($arr, $i[1], $j[1]);}
                         $i[1] += 1;
                         $j[1] += -1;
-                        $continue_counter = 1;break;
+                        $continue_label = "b";break;
                       }
                       $j[1] += -1;
                       continue;
                     }
-                    if ($continue_counter > 0) {
-                      $continue_counter -= 1;
-                      break;
-                    }
-                    else if ($continue_counter === 0) {
-                      $continue_counter = null;
-                      continue;
-                    }
+                    if ($continue_label !== null) {break;}
                   }
                   $i[1] += 1;
                   continue;
                 }
-                if ($continue_counter > 0) {
-                  $continue_counter -= 1;
-                  break;
-                }
-                else if ($continue_counter === 0) {
-                  $continue_counter = null;
-                  continue;
-                }
+                if ($continue_label === "b") {continue;}
+                else if ($continue_label !== null) {break;}
               }
               if ((int) ($j[1] - $lo__0) <= (int) ($hi__0 - $i[1])) {
                 $qsort->contents($lo__0, $j[1]);
                 $lo__1 = $i[1];
                 $lo__0 = $lo__1;
-                $continue_counter = 0;break;
+                $continue_label = "a";break;
               }
               $qsort->contents($i[1], $hi__0);
               $hi__1 = $j[1];
               $hi__0 = $hi__1;
-              $continue_counter = 0;break;
+              $continue_label = "a";break;
             }
-            if ($continue_counter > 0) {
-              $continue_counter -= 1;
-              break;
-            }
-            else if ($continue_counter === 0) {
-              $continue_counter = null;
-              continue;
-            }
+            if ($continue_label === "a") {continue;}
+            else if ($continue_label !== null) {break;}
           }
           return $d;
         }

--- a/rehack_tests/stdlib/stdlib.cma.php/Stream.php
+++ b/rehack_tests/stdlib/stdlib.cma.php/Stream.php
@@ -95,7 +95,7 @@ final class Stream {
               $match = $get_data->contents($count, $d1);
               if ($is_int($match)) {
                 $d__0 = $d2;
-                $continue_label = "switch";break;
+                $continue_label = "#";break;
               }
               else {
                 if (0 === $match[0]) {
@@ -113,7 +113,7 @@ final class Stream {
                 ? $f[1]
                 : (246 === $q ? $call1($CamlinternalLazy[2], $f) : ($f));
               $d__0 = $d__1;
-              $continue_label = "switch";break;
+              $continue_label = "#";break;
             // FALLTHROUGH
             case 3:
               $r = $d__0[1];
@@ -143,7 +143,7 @@ final class Stream {
               $b__0[4] = (int) ($b__0[4] + 1);
               return Vector{0, $r__0, $d__0};
             }
-          if ($continue_label === "switch") {continue;}
+          if ($continue_label === "#") {continue;}
         }
         return $d__0;
       }
@@ -179,7 +179,7 @@ final class Stream {
                 ? $f[1]
                 : (246 === $m ? $call1($CamlinternalLazy[2], $f) : ($f));
               $s[2] = $n;
-              $continue_label = "switch";break;
+              $continue_label = "#";break;
             // FALLTHROUGH
             case 3:
               $o = $l[1];
@@ -195,7 +195,7 @@ final class Stream {
               if (0 === $b[3]) {$s[2] = 0;return 0;}
               return Vector{0, $caml_bytes_unsafe_get($b[2], $b[4])};
             }
-          if ($continue_label === "switch") {continue;}
+          if ($continue_label === "#") {continue;}
         }
       }
     };

--- a/rehack_tests/stdlib/stdlib.cma.php/Stream.php
+++ b/rehack_tests/stdlib/stdlib.cma.php/Stream.php
@@ -86,60 +86,64 @@ final class Stream {
       $d__0 = $d;
       for (;;) {
         if (! $is_int($d__0)) {
-          if ($d__0[0] === 1) {
-            $d2 = $d__0[2];
-            $d1 = $d__0[1];
-            $match = $get_data->contents($count, $d1);
-            if ($is_int($match)) {
-              $d__0 = $d2;
-              continue;
-            }
-            else {
-              if (0 === $match[0]) {
-                $d11 = $match[2];
-                $a__0 = $match[1];
-                return Vector{0, $a__0, Vector{1, $d11, $d2}};
+          $continue_label = null;
+          switch($d__0[0]) {
+            // FALLTHROUGH
+            case 1:
+              $d2 = $d__0[2];
+              $d1 = $d__0[1];
+              $match = $get_data->contents($count, $d1);
+              if ($is_int($match)) {
+                $d__0 = $d2;
+                $continue_label = "switch";break;
               }
-              throw $runtime["caml_wrap_thrown_exception"](Vector{0, $Assert_failure, $a}) as \Throwable;
-            }
-          }
-          else if ($d__0[0] === 2) {
-            $f = $d__0[1];
-            $q = $caml_obj_tag($f);
-            $d__1 = 250 === $q
-              ? $f[1]
-              : (246 === $q ? $call1($CamlinternalLazy[2], $f) : ($f));
-            $d__0 = $d__1;
-            continue;
-          }
-          else if ($d__0[0] === 3) {
-            $r = $d__0[1];
-            $s = $r[1];
-            if ($s) {
-              $t = $s[1];
-              if ($t) {
-                $a__1 = $t[1];
-                $r[1] = 0;
-                return Vector{0, $a__1, $d__0};
+              else {
+                if (0 === $match[0]) {
+                  $d11 = $match[2];
+                  $a__0 = $match[1];
+                  return Vector{0, $a__0, Vector{1, $d11, $d2}};
+                }
+                throw $runtime["caml_wrap_thrown_exception"](Vector{0, $Assert_failure, $a}) as \Throwable;
               }
+            // FALLTHROUGH
+            case 2:
+              $f = $d__0[1];
+              $q = $caml_obj_tag($f);
+              $d__1 = 250 === $q
+                ? $f[1]
+                : (246 === $q ? $call1($CamlinternalLazy[2], $f) : ($f));
+              $d__0 = $d__1;
+              $continue_label = "switch";break;
+            // FALLTHROUGH
+            case 3:
+              $r = $d__0[1];
+              $s = $r[1];
+              if ($s) {
+                $t = $s[1];
+                if ($t) {
+                  $a__1 = $t[1];
+                  $r[1] = 0;
+                  return Vector{0, $a__1, $d__0};
+                }
+                return 0;
+              }
+              $match__0 = $call1($r[2], $count);
+              if ($match__0) {
+                $a__2 = $match__0[1];
+                return Vector{0, $a__2, $d__0};
+              }
+              $r[1] = $b;
               return 0;
+            // FALLTHROUGH
+            case 4:
+              $b__0 = $d__0[1];
+              if ($b__0[3] <= $b__0[4]) {$fill_buff($b__0);}
+              if (0 === $b__0[3]) {return 0;}
+              $r__0 = $caml_bytes_unsafe_get($b__0[2], $b__0[4]);
+              $b__0[4] = (int) ($b__0[4] + 1);
+              return Vector{0, $r__0, $d__0};
             }
-            $match__0 = $call1($r[2], $count);
-            if ($match__0) {
-              $a__2 = $match__0[1];
-              return Vector{0, $a__2, $d__0};
-            }
-            $r[1] = $b;
-            return 0;
-          }
-          else if ($d__0[0] === 4) {
-            $b__0 = $d__0[1];
-            if ($b__0[3] <= $b__0[4]) {$fill_buff($b__0);}
-            if (0 === $b__0[3]) {return 0;}
-            $r__0 = $caml_bytes_unsafe_get($b__0[2], $b__0[4]);
-            $b__0[4] = (int) ($b__0[4] + 1);
-            return Vector{0, $r__0, $d__0};
-          }
+          if ($continue_label === "switch") {continue;}
         }
         return $d__0;
       }
@@ -149,44 +153,49 @@ final class Stream {
         $l = $s[2];
         if ($is_int($l)) {return 0;}
         else {
-          if ($l[0] === 0) {
-            $a = $l[1];return Vector{0, $a};
-          }
-          else if ($l[0] === 1) {
-            $d = $get_data->contents($s[1], $s[2]);
-            if ($is_int($d)) {return 0;}
-            else {
-              if (0 === $d[0]) {
-                $a__0 = $d[1];
-                $s[2] = $d;
-                return Vector{0, $a__0};
+          $continue_label = null;
+          switch($l[0]) {
+            // FALLTHROUGH
+            case 0:
+              $a = $l[1];
+              return Vector{0, $a};
+            // FALLTHROUGH
+            case 1:
+              $d = $get_data->contents($s[1], $s[2]);
+              if ($is_int($d)) {return 0;}
+              else {
+                if (0 === $d[0]) {
+                  $a__0 = $d[1];
+                  $s[2] = $d;
+                  return Vector{0, $a__0};
+                }
+                throw $runtime["caml_wrap_thrown_exception"](Vector{0, $Assert_failure, $c}) as \Throwable;
               }
-              throw $runtime["caml_wrap_thrown_exception"](Vector{0, $Assert_failure, $c}) as \Throwable;
+            // FALLTHROUGH
+            case 2:
+              $f = $l[1];
+              $m = $caml_obj_tag($f);
+              $n = 250 === $m
+                ? $f[1]
+                : (246 === $m ? $call1($CamlinternalLazy[2], $f) : ($f));
+              $s[2] = $n;
+              $continue_label = "switch";break;
+            // FALLTHROUGH
+            case 3:
+              $o = $l[1];
+              $p = $o[1];
+              if ($p) {$a__1 = $p[1];return $a__1;}
+              $x = $call1($o[2], $s[1]);
+              $o[1] = Vector{0, $x};
+              return $x;
+            // FALLTHROUGH
+            default:
+              $b = $l[1];
+              if ($b[3] <= $b[4]) {$fill_buff($b);}
+              if (0 === $b[3]) {$s[2] = 0;return 0;}
+              return Vector{0, $caml_bytes_unsafe_get($b[2], $b[4])};
             }
-          }
-          else if ($l[0] === 2) {
-            $f = $l[1];
-            $m = $caml_obj_tag($f);
-            $n = 250 === $m
-              ? $f[1]
-              : (246 === $m ? $call1($CamlinternalLazy[2], $f) : ($f));
-            $s[2] = $n;
-            continue;
-          }
-          else if ($l[0] === 3) {
-            $o = $l[1];
-            $p = $o[1];
-            if ($p) {$a__1 = $p[1];return $a__1;}
-            $x = $call1($o[2], $s[1]);
-            $o[1] = Vector{0, $x};
-            return $x;
-          }
-          else {
-            $b = $l[1];
-            if ($b[3] <= $b[4]) {$fill_buff($b);}
-            if (0 === $b[3]) {$s[2] = 0;return 0;}
-            return Vector{0, $caml_bytes_unsafe_get($b[2], $b[4])};
-          }
+          if ($continue_label === "switch") {continue;}
         }
       }
     };

--- a/rehack_tests/switch_continue/switch_continue.js
+++ b/rehack_tests/switch_continue/switch_continue.js
@@ -1087,6 +1087,13 @@ caml_register_global(1, Sys_error, "Sys_error");
 
 caml_register_global(0, Out_of_memory, "Out_of_memory");
 
+var a = [
+  0,
+  caml_new_string("rehack_tests/switch_continue/switch_continue.re"),
+  72,
+  18
+];
+
 caml_fresh_oo_id(0);
 
 function string_of_int(n) {
@@ -1108,10 +1115,10 @@ function flush_all(param) {
         var a = param__0[1];
         try {
           caml_ml_flush(a);
-        } catch (a) {
-          a = caml_wrap_exception(a);
-          if (a[1] !== Sys_error) {
-            throw caml_wrap_thrown_exception_reraise(a);
+        } catch (b) {
+          b = caml_wrap_exception(b);
+          if (b[1] !== Sys_error) {
+            throw caml_wrap_thrown_exception_reraise(b);
           }
         }
         var param__0 = l;
@@ -1248,5 +1255,31 @@ print_endline(string_of_int(f1(0)));
 print_endline(string_of_int(f2(0)));
 
 print_endline(string_of_int(f3(0)));
+
+function h0__0(c) {
+  for (;;) {
+    if (40 === c) {
+      continue;
+    }
+    if (123 <= c) {
+      if (!(126 <= c)) {
+        var switcher = (c + -123) | 0;
+        switch (switcher) {
+          case 0:
+            continue;
+          case 1:
+            break;
+          default:
+            throw caml_wrap_thrown_exception(Not_found);
+        }
+      }
+    } else if (95 === c) {
+      continue;
+    }
+    throw caml_wrap_thrown_exception([0, Match_failure, a]);
+  }
+}
+
+h0__0(120);
 
 do_at_exit(0);

--- a/rehack_tests/switch_continue/switch_continue.js
+++ b/rehack_tests/switch_continue/switch_continue.js
@@ -1280,6 +1280,31 @@ function h0__0(c) {
   }
 }
 
-h0__0(120);
+function h1(t) {
+  for (;;) {
+    if (0 === t) {
+      switch (t) {
+        case 0:
+          continue;
+        case 1:
+          return 2;
+        default:
+          return 3;
+      }
+    }
+    switch (t) {
+      case 0:
+        return 1;
+      case 1:
+        return 2;
+      default:
+        return 3;
+    }
+  }
+}
+
+print_endline(string_of_int(h0__0(104)));
+
+print_endline(string_of_int(h1(0)));
 
 do_at_exit(0);

--- a/rehack_tests/switch_continue/switch_continue.php
+++ b/rehack_tests/switch_continue/switch_continue.php
@@ -287,7 +287,6 @@ $f3 = function(dynamic $t) {
         break;
         // FALLTHROUGH
       case 1:
-        $continue_label = null;
         switch ($t__0) {
             // FALLTHROUGH
           case 0:

--- a/rehack_tests/switch_continue/switch_continue.php
+++ b/rehack_tests/switch_continue/switch_continue.php
@@ -237,16 +237,27 @@ $f0 = function(dynamic $t) {
 };
 $f1 = function(dynamic $t) {
   $t__0 = $t;
-  for (; ; )
-    if ($t__0 === 0) {
-      $t__0 = 1;
-      continue;
-    } else if ($t__0 === 1) {
-      $t__0 = 2;
-      continue;
-    } else {
-      return 3;
+  for (; ; ) {
+    $continue_label = null;
+    switch ($t__0) {
+        // FALLTHROUGH
+      case 0:
+        $t__0 = 1;
+        $continue_label = "switch";
+        break;
+        // FALLTHROUGH
+      case 1:
+        $t__0 = 2;
+        $continue_label = "switch";
+        break;
+        // FALLTHROUGH
+      default:
+        return 3;
     }
+    if ($continue_label === "switch") {
+      continue;
+    }
+  }
 };
 $f2->contents = function(dynamic $t) use ($f2) {
   switch ($t) {
@@ -266,23 +277,43 @@ $f2->contents = function(dynamic $t) use ($f2) {
 };
 $f3 = function(dynamic $t) {
   $t__0 = $t;
-  for (; ; )
-    if ($t__0 === 0) {
-      $t__0 = 1;
-      continue;
-    } else if ($t__0 === 1) {
-      if ($t__0 === 0) {
+  for (; ; ) {
+    $continue_label = null;
+    switch ($t__0) {
+        // FALLTHROUGH
+      case 0:
         $t__0 = 1;
-        continue;
-      } else if ($t__0 === 1) {
-        $t__0 = 2;
-        continue;
-      } else {
+        $continue_label = "switch";
+        break;
+        // FALLTHROUGH
+      case 1:
+        $continue_label = null;
+        switch ($t__0) {
+            // FALLTHROUGH
+          case 0:
+            $t__0 = 1;
+            $continue_label = "switch";
+            break;
+            // FALLTHROUGH
+          case 1:
+            $t__0 = 2;
+            $continue_label = "switch";
+            break;
+            // FALLTHROUGH
+          default:
+            return 3;
+        }
+        if ($continue_label !== null) {
+          break;
+        }
+        // FALLTHROUGH
+      default:
         return 3;
-      }
-    } else {
-      return 3;
     }
+    if ($continue_label === "switch") {
+      continue;
+    }
+  }
 };
 
 $print_endline($string_of_int($f0(0)));
@@ -306,12 +337,21 @@ $h0__0 = function(dynamic $c) use (
     if (123 <= $c) {
       if (!(126 <= $c)) {
         $switcher = (int)($c + -123);
-        if ($switcher === 0) {
+        $continue_label = null;
+        switch ($switcher) {
+            // FALLTHROUGH
+          case 0:
+            $continue_label = "switch";
+            break;
+            // FALLTHROUGH
+          case 1:
+            break;
+            // FALLTHROUGH
+          default:
+            throw $caml_wrap_thrown_exception($Not_found) as \Throwable;
+        }
+        if ($continue_label === "switch") {
           continue;
-        } else if ($switcher === 1) {
-          break;
-        } else {
-          throw $caml_wrap_thrown_exception($Not_found) as \Throwable;
         }
       }
     } else {

--- a/rehack_tests/switch_continue/switch_continue.php
+++ b/rehack_tests/switch_continue/switch_continue.php
@@ -382,7 +382,6 @@ $h1 = function(dynamic $t) {
         continue;
       }
     }
-    $continue_label = null;
     switch ($t) {
         // FALLTHROUGH
       case 0:
@@ -393,9 +392,6 @@ $h1 = function(dynamic $t) {
         // FALLTHROUGH
       default:
         return 3;
-    }
-    if ($continue_label === "switch") {
-      continue;
     }
   }
 };

--- a/rehack_tests/switch_continue/switch_continue.php
+++ b/rehack_tests/switch_continue/switch_continue.php
@@ -104,6 +104,13 @@ $caml_register_global(1, $Sys_error, "Sys_error");
 
 $caml_register_global(0, $Out_of_memory, "Out_of_memory");
 
+$a = Vector {
+  0,
+  $caml_new_string("rehack_tests/switch_continue/switch_continue.re"),
+  72,
+  18,
+};
+
 $caml_fresh_oo_id(0);
 
 $string_of_int = function(dynamic $n) use ($caml_new_string) {
@@ -136,10 +143,10 @@ $flush_all = function(dynamic $param) use (
         $a = $param__0[1];
         try {
           $caml_ml_flush($a);
-        } catch (\Throwable $a) {
-          $a = $caml_wrap_exception($a);
-          if ($a[1] !== $Sys_error) {
-            throw $caml_wrap_thrown_exception_reraise($a) as \Throwable;
+        } catch (\Throwable $b) {
+          $b = $caml_wrap_exception($b);
+          if ($b[1] !== $Sys_error) {
+            throw $caml_wrap_thrown_exception_reraise($b) as \Throwable;
           }
         }
         $param__0 = $l;
@@ -285,5 +292,38 @@ $print_endline($string_of_int($f1(0)));
 $print_endline($string_of_int($f2->contents(0)));
 
 $print_endline($string_of_int($f3(0)));
+
+$h0__0 = function(dynamic $c) use (
+  $Match_failure,
+  $Not_found,
+  $a,
+  $caml_wrap_thrown_exception,
+) {
+  for (; ; ) {
+    if (40 === $c) {
+      continue;
+    }
+    if (123 <= $c) {
+      if (!(126 <= $c)) {
+        $switcher = (int)($c + -123);
+        if ($switcher === 0) {
+          continue;
+        } else if ($switcher === 1) {
+          break;
+        } else {
+          throw $caml_wrap_thrown_exception($Not_found) as \Throwable;
+        }
+      }
+    } else {
+      if (95 === $c) {
+        continue;
+      }
+    }
+    throw $caml_wrap_thrown_exception(Vector {0, $Match_failure, $a}) as
+      \Throwable;
+  }
+};
+
+$h0__0(120);
 
 $do_at_exit(0);

--- a/rehack_tests/switch_continue/switch_continue.php
+++ b/rehack_tests/switch_continue/switch_continue.php
@@ -362,7 +362,46 @@ $h0__0 = function(dynamic $c) use (
       \Throwable;
   }
 };
+$h1 = function(dynamic $t) {
+  for (; ; ) {
+    if (0 === $t) {
+      $continue_label = null;
+      switch ($t) {
+          // FALLTHROUGH
+        case 0:
+          $continue_label = "switch";
+          break;
+          // FALLTHROUGH
+        case 1:
+          return 2;
+          // FALLTHROUGH
+        default:
+          return 3;
+      }
+      if ($continue_label === "switch") {
+        continue;
+      }
+    }
+    $continue_label = null;
+    switch ($t) {
+        // FALLTHROUGH
+      case 0:
+        return 1;
+        // FALLTHROUGH
+      case 1:
+        return 2;
+        // FALLTHROUGH
+      default:
+        return 3;
+    }
+    if ($continue_label === "switch") {
+      continue;
+    }
+  }
+};
 
-$h0__0(120);
+$print_endline($string_of_int($h0__0(104)));
+
+$print_endline($string_of_int($h1(0)));
 
 $do_at_exit(0);

--- a/rehack_tests/switch_continue/switch_continue.php
+++ b/rehack_tests/switch_continue/switch_continue.php
@@ -243,18 +243,18 @@ $f1 = function(dynamic $t) {
         // FALLTHROUGH
       case 0:
         $t__0 = 1;
-        $continue_label = "switch";
+        $continue_label = "#";
         break;
         // FALLTHROUGH
       case 1:
         $t__0 = 2;
-        $continue_label = "switch";
+        $continue_label = "#";
         break;
         // FALLTHROUGH
       default:
         return 3;
     }
-    if ($continue_label === "switch") {
+    if ($continue_label === "#") {
       continue;
     }
   }
@@ -283,7 +283,7 @@ $f3 = function(dynamic $t) {
         // FALLTHROUGH
       case 0:
         $t__0 = 1;
-        $continue_label = "switch";
+        $continue_label = "#";
         break;
         // FALLTHROUGH
       case 1:
@@ -291,12 +291,12 @@ $f3 = function(dynamic $t) {
             // FALLTHROUGH
           case 0:
             $t__0 = 1;
-            $continue_label = "switch";
+            $continue_label = "#";
             break;
             // FALLTHROUGH
           case 1:
             $t__0 = 2;
-            $continue_label = "switch";
+            $continue_label = "#";
             break;
             // FALLTHROUGH
           default:
@@ -309,7 +309,7 @@ $f3 = function(dynamic $t) {
       default:
         return 3;
     }
-    if ($continue_label === "switch") {
+    if ($continue_label === "#") {
       continue;
     }
   }
@@ -340,7 +340,7 @@ $h0__0 = function(dynamic $c) use (
         switch ($switcher) {
             // FALLTHROUGH
           case 0:
-            $continue_label = "switch";
+            $continue_label = "#";
             break;
             // FALLTHROUGH
           case 1:
@@ -349,7 +349,7 @@ $h0__0 = function(dynamic $c) use (
           default:
             throw $caml_wrap_thrown_exception($Not_found) as \Throwable;
         }
-        if ($continue_label === "switch") {
+        if ($continue_label === "#") {
           continue;
         }
       }
@@ -369,7 +369,7 @@ $h1 = function(dynamic $t) {
       switch ($t) {
           // FALLTHROUGH
         case 0:
-          $continue_label = "switch";
+          $continue_label = "#";
           break;
           // FALLTHROUGH
         case 1:
@@ -378,7 +378,7 @@ $h1 = function(dynamic $t) {
         default:
           return 3;
       }
-      if ($continue_label === "switch") {
+      if ($continue_label === "#") {
         continue;
       }
     }

--- a/rehack_tests/switch_continue/switch_continue.re
+++ b/rehack_tests/switch_continue/switch_continue.re
@@ -68,3 +68,14 @@ print_endline(string_of_int(f0(A)));
 print_endline(string_of_int(f1(A)));
 print_endline(string_of_int(f2(A)));
 print_endline(string_of_int(f3(A)));
+
+let rec h0 = c => {
+  switch (c) {
+  | '_' => h0(c)
+  | '{' => h0(c)
+  | '(' => h0(c)
+  | '}' => raise(Not_found)
+  };
+};
+
+let x = h0('x');

--- a/rehack_tests/switch_continue/switch_continue.re
+++ b/rehack_tests/switch_continue/switch_continue.re
@@ -78,4 +78,22 @@ let rec h0 = c => {
   };
 };
 
-let x = h0('x');
+/* bug: extra continue_label on second switch */
+let rec h1 = (t) => {
+  if (t == A) {
+    switch (t) {
+    | A => h1(t)
+    | B => 2
+    | C => 3
+    };
+  } else {
+    switch (t) {
+    | A => 1
+    | B => 2
+    | C => 3
+    };
+  };
+};
+
+print_endline(string_of_int(h0('h')));
+print_endline(string_of_int(h1(A)));


### PR DESCRIPTION
Remove unnecessary continue checks by tracking continue labels that are unshielded and some context, like whether a node is inside a labeled/unlabeled for loop or switch. 