### PR TITLE
more resilient hashing that considers order of items

### DIFF
--- a/compiler/lib/code.ml
+++ b/compiler/lib/code.ml
@@ -314,13 +314,12 @@ type program =
 
 (* Because OCaml's built in Hashtb hash only traverses to a certain depth
  * we have to do some outside traversal to get a complete hash. *)
-
 let hash_block block =
   Hashtbl.hash_param 256 256 block.params
   + Hashtbl.hash_param 256 256 block.handler
   + List.fold_left
       ~init:0
-      ~f:(fun cur itm -> cur + Hashtbl.hash_param 256 256 itm)
+      ~f:(fun cur itm -> (2 * (cur + Hashtbl.hash_param 256 256 itm)))
       block.body
   + Hashtbl.hash_param 256 256 block.branch
 

--- a/compiler/lib/ocaml_compiler.ml
+++ b/compiler/lib/ocaml_compiler.ml
@@ -250,9 +250,7 @@ module IdentUtilities = struct
           (Ident.name v.ident :: table_contents_rec sz r rem)
 
   let table_contents_names_for_hashing sz (t : 'a Ident_.tbl) =
-    List.sort
-      ~cmp:(fun (i) (j) -> compare i j)
-      (table_contents_rec sz (Obj.magic (t : 'a Ident_.tbl) : 'a Ident_.tbl') [])
+      table_contents_rec sz (Obj.magic (t : 'a Ident_.tbl) : 'a Ident_.tbl') []
 end
 
 module Ident = struct


### PR DESCRIPTION
Just opening this pull request for posterity. We should probably do something like this even though it didn't fix this one particular problem I found with ordered items in a module not changing the hash (byte code was functionally equivalent but you'd want it to recompile to adjust the names of things).