### PR TITLE
Fail for require, export, runtime nodes in JS and PHP

### DIFF
--- a/compiler/lib/javascript_from_rehp.re
+++ b/compiler/lib/javascript_from_rehp.re
@@ -115,7 +115,10 @@ and from_expression = e =>
   | EAccess(e1, e2) =>
     Javascript.EAccess(from_expression(e1), from_expression(e2))
   | EStructAccess(e, i) =>
-    Javascript.EAccess(from_expression(e), Javascript.ENum(float_of_int(i)))
+    Javascript.EAccess(
+      from_expression(e),
+      Javascript.ENum(float_of_int(i)),
+    )
   | EArrAccess(e1, e2) =>
     Javascript.EAccess(from_expression(e1), from_expression(e2))
   | EVectlength(e) =>
@@ -146,6 +149,10 @@ and from_expression = e =>
   | EInt(i) => ENum(float_of_int(i))
   | EQuote(s) => EQuote(s)
   | ERegexp(s, sopt) => ERegexp(s, sopt)
+  | ECustomRequire(_) => failwith("ECustonRequire not supported for JS")
+  | ECustomRegister(_) => failwith("ECustonRegister not supported for JS")
+  | ERequire(_) => failwith("ERequire not supported for JS")
+  | ERuntime => failwith("ERuntime not supported for JS")
   }
 and from_statement = e =>
   switch (e) {
@@ -172,7 +179,7 @@ and from_statement = e =>
       },
     )
   | Rehp.Loop_statement(stmt, loc) =>
-    For_statement(Left(None), None, None, (from_statement(stmt), loc));
+    For_statement(Left(None), None, None, (from_statement(stmt), loc))
   | Rehp.Continue_statement(lbl, _depth) => Continue_statement(lbl)
   | Rehp.Break_statement(lbl) => Break_statement(lbl)
   | Rehp.Return_statement(eo) =>
@@ -180,11 +187,7 @@ and from_statement = e =>
   /* | With_statement of expression * statement */
   | Rehp.Labelled_statement(lbl, (stmt, loc)) =>
     Labelled_statement(lbl, (from_statement(stmt), loc))
-  | Rehp.Switch_statement(
-      e,
-      case_clause_list,
-      stmt_lst,
-    ) =>
+  | Rehp.Switch_statement(e, case_clause_list, stmt_lst) =>
     let e = from_expression(e);
     let case_clause_lst = from_case_clause_list(case_clause_list);
     /* Backward-compatible behavior, TODO: cleanup JS Ast and printing */

--- a/compiler/lib/js_simpl.re
+++ b/compiler/lib/js_simpl.re
@@ -92,6 +92,10 @@ let rec enot_rec = e => {
         J.EUn(J.Not, e),
         1,
       )
+    | ECustomRequire(_) => failwith("ECustomRequire not supported for JS")
+    | ECustomRegister(_) => failwith("ECustonRegister not supported for JS")
+    | ERequire(_) => failwith("ERequire not supported for JS")
+    | ERuntime => failwith("ERuntime not supported for JS")
     };
 
   if (cost <= 1) {
@@ -383,4 +387,8 @@ let rec get_variable = acc =>
       a,
     )
   | J.EObj(l) =>
-    List.fold_left((acc, (_, e1)) => get_variable(acc, e1), acc, l);
+    List.fold_left((acc, (_, e1)) => get_variable(acc, e1), acc, l)
+  | ECustomRequire(_) => failwith("ECustomRequire not supported for JS")
+  | ECustomRegister(_) => failwith("ECustonRegister not supported for JS")
+  | ERequire(_) => failwith("ERequire not supported for JS")
+  | ERuntime => failwith("ERuntime not supported for JS");

--- a/compiler/lib/php_from_rehp.re
+++ b/compiler/lib/php_from_rehp.re
@@ -718,6 +718,11 @@ let rec expression = (input: input, x) =>
   | Rehp.EInt(n) => (emptyOutput, Php.EInt(n))
   | Rehp.EQuote(s) => (emptyOutput, Php.EQuote(s))
   | Rehp.ERegexp(x, y) => (emptyOutput, Php.ERegexp(x, y))
+  | Rehp.ECustomRequire(_) => failwith("ECustomRequire not supported for PHP")
+  | Rehp.ECustomRegister(_) =>
+    failwith("ECustonRegister not supported for PHP")
+  | Rehp.ERequire(_) => failwith("ERequire not supported for PHP")
+  | Rehp.ERuntime => failwith("ERuntime not supported for PHP")
   }
 /*
  * For a given Rehp unary operator, and an expression that has already been
@@ -1070,10 +1075,7 @@ and statement = (curOut, input: input, x) => {
     | Rehp.Return_statement(e) =>
       let (eOut, eMapped) = optOutput(expression(input), e);
       (outAppend(curOut, eOut), Return_statement(eMapped));
-    | Rehp.Labelled_statement(
-        lbl,
-        (Rehp.Loop_statement(s, loc), _loc2),
-      ) =>
+    | Rehp.Labelled_statement(lbl, (Rehp.Loop_statement(s, loc), _loc2)) =>
       for_statement(
         curOut,
         input,


### PR DESCRIPTION
These were added in 448c5eab6, but they are not yet used, and they're
creating warnings about incomplete pattern matching in other parts of
the compiler. Removing for now.