### PR TITLE
Fix dummy

### DIFF
--- a/rehack_tests/output/calls.cmo.module.js
+++ b/rehack_tests/output/calls.cmo.module.js
@@ -164,7 +164,7 @@ console.log(cst_fix, cst_me));
 }
 
 var f = runtime["caml_alloc_dummy_function"](1, 2);
-var z = [0];
+var z = [0,0];
 
 caml_update_dummy(f, function(x, y) {return 1;});
 

--- a/rehack_tests/output/calls.cmo.module.php
+++ b/rehack_tests/output/calls.cmo.module.php
@@ -173,7 +173,7 @@ SomeUtilityClass::foo($cst_fix, $cst_me)
       );
     };
     $f = $runtime["caml_alloc_dummy_function"](1, 2);
-    $z = Vector{0} as dynamic;
+    $z = Vector{0, 0} as dynamic;
     
     $caml_update_dummy($f, (dynamic $x, dynamic $y) : dynamic ==> {return 1;});
     

--- a/rehack_tests/output/calls.cmo.module.with.keep.unit.names.js/Calls.js
+++ b/rehack_tests/output/calls.cmo.module.with.keep.unit.names.js/Calls.js
@@ -164,7 +164,7 @@ console.log(cst_fix, cst_me));
 }
 
 var f = runtime["caml_alloc_dummy_function"](1, 2);
-var z = [0];
+var z = [0,0];
 
 caml_update_dummy(f, function(x, y) {return 1;});
 

--- a/rehack_tests/output/calls/Calls.cma.js/Calls.js
+++ b/rehack_tests/output/calls/Calls.cma.js/Calls.js
@@ -164,7 +164,7 @@ console.log(cst_fix, cst_me));
 }
 
 var f = runtime["caml_alloc_dummy_function"](1, 2);
-var z = [0];
+var z = [0,0];
 
 caml_update_dummy(f, function(x, y) {return 1;});
 

--- a/rehack_tests/output/calls/Calls.cma.php/Calls.php
+++ b/rehack_tests/output/calls/Calls.cma.php/Calls.php
@@ -173,7 +173,7 @@ SomeUtilityClass::foo($cst_fix, $cst_me)
       );
     };
     $f = $runtime["caml_alloc_dummy_function"](1, 2);
-    $z = Vector{0} as dynamic;
+    $z = Vector{0, 0} as dynamic;
     
     $caml_update_dummy($f, (dynamic $x, dynamic $y) : dynamic ==> {return 1;});
     

--- a/runtime/rehack/php/runtime.php
+++ b/runtime/rehack/php/runtime.php
@@ -1633,7 +1633,7 @@ function caml_update_dummy(dynamic $x, KeyedContainer<int, mixed> $y): int {
     return 0;
   }
   for ($i = 0; $i < C\count($y); $i++) {
-    $x[] = $y[$i];
+    $x[$i] = $y[$i];
   }
   return 0;
 }


### PR DESCRIPTION
Fixes size of allocated dummy cell to match the size of block used for subsequent update. Also fixes #40.