### PR TITLE
Manual hash buster

### DIFF
--- a/buildTest.sh
+++ b/buildTest.sh
@@ -90,10 +90,12 @@ echo "./rehack_tests/output/stringHelper.cmo.module.php"
 export OCAMLRUNPARAM=b && time js_of_ocaml --keep-unit-names --enable excwrap --enable wrapped-exceptions --disable simplify_ifdecl  --noinline --disable shortvar --pretty --custom-header "file:./rehack_tests/templates/php-module-header.php" --backend php "${1}"/default/rehack_tests/strings/.strings.eobjs/byte/stringHelper.cmo -o ./rehack_tests/output/stringHelper.cmo.module.php
 
 # Custom library
+# Also test hash busting.
 echo "./rehack_tests/output/my-lib.cma.php"
 # NODE_PATH="${PWD}/rehack_tests/my-lib/my-lib.cma.js/:${PWD}/rehack_tests/output/stdlib.cma.js:${PWD}/runtime/rehack/js/" node -e 'require("MyLib")'
-export OCAMLRUNPARAM=b && time js_of_ocaml --use-hashing --keep-unit-names --enable excwrap --async-compilation-summary --enable wrapped-exceptions --disable simplify_ifdecl  --noinline --disable shortvar --pretty --backend php --custom-header "file:./rehack_tests/templates/php-module-header.php" "${1}"/default/rehack_tests/my-lib/MyLib.cma -o ./rehack_tests/output/my-lib.cma.php/
-export OCAMLRUNPARAM=b && time js_of_ocaml --use-hashing --keep-unit-names --enable excwrap --enable wrapped-exceptions --disable simplify_ifdecl  --noinline --disable shortvar --pretty --backend js  --custom-header "file:./rehack_tests/templates/common-js-module-header.js" "${1}"/default/rehack_tests/my-lib/MyLib.cma -o ./rehack_tests/output/my-lib.cma.js/
+export REHP_HASH_BUST="v4" && time js_of_ocaml --use-hashing --keep-unit-names --enable excwrap --async-compilation-summary --enable wrapped-exceptions --disable simplify_ifdecl  --noinline --disable shortvar --pretty --backend php --custom-header "file:./rehack_tests/templates/php-module-header.php" "${1}"/default/rehack_tests/my-lib/MyLib.cma -o ./rehack_tests/output/my-lib.cma.php/
+export REHP_HASH_BUST="v4" && time js_of_ocaml --use-hashing --keep-unit-names --enable excwrap --enable wrapped-exceptions --disable simplify_ifdecl  --noinline --disable shortvar --pretty --backend js  --custom-header "file:./rehack_tests/templates/common-js-module-header.js" "${1}"/default/rehack_tests/my-lib/MyLib.cma -o ./rehack_tests/output/my-lib.cma.js/
+unset REHP_HASH_BUST
 
 # Custom library
 echo "./rehack_tests/output/SeparateCompilation.cma.php"

--- a/rehack_tests/output/my-lib.cma.js/MyLib.js
+++ b/rehack_tests/output/my-lib.cma.js/MyLib.js
@@ -266,4 +266,4 @@ module.exports.get = module.exports[20];
 module.exports.construct = module.exports[22];
 module.exports.genThisShouldBeAsyncTransformed1 = module.exports[23];
 
-/*____hashes flags: 589793685 bytecode: 90287558315 debug-data: 22114087654 primitives: 314532832*/
+/*____hashes flags: 589793685 bytecode: 90287558315 debug-data: 22114087654 primitives: 314532832 rehp-hash-bust:v4*/

--- a/rehack_tests/output/my-lib.cma.js/MyLib__.js
+++ b/rehack_tests/output/my-lib.cma.js/MyLib__.js
@@ -19,4 +19,4 @@ module.exports = MyLib;
 }} */
 module.exports = ((module.exports /*:: : any*/) /*:: :Exports */);
 
-/*____hashes flags: 589793685 bytecode: 4874759914 debug-data: 129913994 primitives: 1058613066*/
+/*____hashes flags: 589793685 bytecode: 4874759914 debug-data: 129913994 primitives: 1058613066 rehp-hash-bust:v4*/

--- a/rehack_tests/output/my-lib.cma.js/MyLib__MyLibUtility.js
+++ b/rehack_tests/output/my-lib.cma.js/MyLib__MyLibUtility.js
@@ -31,4 +31,4 @@ module.exports = MyLib_MyLibUtility;
 module.exports = ((module.exports /*:: : any*/) /*:: :Exports */);
 module.exports.thisIsAUtilityFunction = module.exports[1];
 
-/*____hashes flags: 589793685 bytecode: 8526643038 debug-data: 1020972089 primitives: 1058613066*/
+/*____hashes flags: 589793685 bytecode: 8526643038 debug-data: 1020972089 primitives: 1058613066 rehp-hash-bust:v4*/

--- a/rehack_tests/output/my-lib.cma.php/MyLib.php
+++ b/rehack_tests/output/my-lib.cma.php/MyLib.php
@@ -257,4 +257,4 @@ final class MyLib {
   }
 
 }
-/*____hashes flags: 1314811087 bytecode: 90287558315 debug-data: 22114087654 primitives: 314532832*/
+/*____hashes flags: 1314811087 bytecode: 90287558315 debug-data: 22114087654 primitives: 314532832 rehp-hash-bust:v4*/

--- a/rehack_tests/output/my-lib.cma.php/MyLib__.php
+++ b/rehack_tests/output/my-lib.cma.php/MyLib__.php
@@ -19,4 +19,4 @@ final class MyLib__ {
   }
 
 }
-/*____hashes flags: 1314811087 bytecode: 4874759914 debug-data: 129913994 primitives: 1058613066*/
+/*____hashes flags: 1314811087 bytecode: 4874759914 debug-data: 129913994 primitives: 1058613066 rehp-hash-bust:v4*/

--- a/rehack_tests/output/my-lib.cma.php/MyLib__MyLibUtility.php
+++ b/rehack_tests/output/my-lib.cma.php/MyLib__MyLibUtility.php
@@ -27,4 +27,4 @@ final class MyLib__MyLibUtility {
   }
 
 }
-/*____hashes flags: 1314811087 bytecode: 8526643038 debug-data: 1020972089 primitives: 1058613066*/
+/*____hashes flags: 1314811087 bytecode: 8526643038 debug-data: 1020972089 primitives: 1058613066 rehp-hash-bust:v4*/


### PR DESCRIPTION
    Add Hash Busting control via environment variable.

    Summary:
    See the comment in `js_of_ocaml.ml`. It is sometimes useful to be able
    to force recompilation.

    I also think we should add back a rehp version in the file output's hash
    footer at some point.
    With this diff you have more control though. Set an env var in your
    environment to rebuild. If using something like esy + Dune rules, this
    wouldn't usually even be an issue because it would purge all the build
    artifacts. But if you are building directly into a monorepo and checking
    in the artifacts it could be an issue and the manual hash buster gives
    repo owners full control of purging artifacts.

    Test Plan:

    Reviewers:

    CC:
