### PR TITLE
Add default breaks to switch statements that fail to match any case

### DIFF
--- a/compiler/lib/php.re
+++ b/compiler/lib/php.re
@@ -156,12 +156,7 @@ and statement =
   | Break_statement
   | Return_statement(option(expression))
   /* | With_statement of expression * statement */
-  | Switch_statement(
-      expression,
-      list(case_clause),
-      option(statement_list),
-      list(case_clause),
-    )
+  | Switch_statement(expression, list(case_clause), statement_list)
   | Throw_statement(expression)
   | Try_statement(block, option((Id.t, block)), option(block))
   | Debugger_statement

--- a/compiler/lib/php.rei
+++ b/compiler/lib/php.rei
@@ -152,12 +152,7 @@ and statement =
   /*
      | With_statement
    */
-  | Switch_statement(
-      expression,
-      list(case_clause),
-      option(statement_list),
-      list(case_clause),
-    )
+  | Switch_statement(expression, list(case_clause), statement_list)
   | Throw_statement(expression)
   | Try_statement(block, option((Id.t, block)), option(block))
   | Debugger_statement

--- a/compiler/lib/php_output.re
+++ b/compiler/lib/php_output.re
@@ -1489,7 +1489,7 @@ module Make = (D: {let source_map: option(Source_map.t);}) => {
       /* There MUST be a space between the return and its
          argument. A line return will not work */
       }
-    | Switch_statement(e, cc, def, cc') =>
+    | Switch_statement(e, cc, def) =>
       PP.start_group(f, 0);
       PP.start_group(f, 0);
       PP.string(f, "switch");
@@ -1529,22 +1529,17 @@ module Make = (D: {let source_map: option(Source_map.t);}) => {
             loop(last, xs);
           }
       );
-      loop(def == None && cc' == [], cc);
-      switch (def) {
-      | None => ()
-      | Some(def) =>
-        PP.string(f, "// FALLTHROUGH");
-        PP.break(f);
-        PP.start_group(f, 0);
-        PP.string(f, "default:");
-        PP.end_group(f);
-        PP.start_group(f, 2);
-        PP.break(f);
-        statement_list(~skip_last_semi=false, f, def);
-        PP.end_group(f);
-        PP.break(f);
-      };
-      loop(true, cc');
+      loop(false, cc);
+      PP.string(f, "// FALLTHROUGH");
+      PP.break(f);
+      PP.start_group(f, 0);
+      PP.string(f, "default:");
+      PP.end_group(f);
+      PP.start_group(f, 2);
+      PP.break(f);
+      statement_list(~skip_last_semi=false, f, def);
+      PP.end_group(f);
+      PP.break(f);
       PP.end_group(f);
       /* Final case handles break */
       /* PP.break(f); */

--- a/rehack_tests/output/js_of_ocaml.cma.php/Js_of_ocaml__Dom.php
+++ b/rehack_tests/output/js_of_ocaml.cma.php/Js_of_ocaml__Dom.php
@@ -135,6 +135,8 @@ final class Js_of_ocaml__Dom {
           // FALLTHROUGH
           case 3:
             return Vector{2, $e};
+          // FALLTHROUGH
+          default:break;
           }
       }
       return Vector{3, $e};

--- a/rehack_tests/output/js_of_ocaml.cma.php/Js_of_ocaml__Dom_html.php
+++ b/rehack_tests/output/js_of_ocaml.cma.php/Js_of_ocaml__Dom_html.php
@@ -2153,6 +2153,8 @@ final class Js_of_ocaml__Dom_html {
             // FALLTHROUGH
             case 34:
               return 81;
+            // FALLTHROUGH
+            default:break;
             }
         }
       }
@@ -2287,6 +2289,8 @@ final class Js_of_ocaml__Dom_html {
             // FALLTHROUGH
             case 214:
               return 50;
+            // FALLTHROUGH
+            default:break;
             }
         }
         else {
@@ -2405,6 +2409,8 @@ final class Js_of_ocaml__Dom_html {
             // FALLTHROUGH
             case 66:
               return 10;
+            // FALLTHROUGH
+            default:break;
             }
         }
       }
@@ -2733,6 +2739,8 @@ final class Js_of_ocaml__Dom_html {
             return $caml_string_notequal($tag, $cst_video__1)
               ? $other($e)
               : (Vector{60, $e});
+          // FALLTHROUGH
+          default:break;
           }
       }
       return $other($e);

--- a/rehack_tests/output/stdlib.cma.php/CamlinternalFormat.php
+++ b/rehack_tests/output/stdlib.cma.php/CamlinternalFormat.php
@@ -4353,6 +4353,8 @@ final class CamlinternalFormat {
             $rest = $fmt[2];
             $ign = $fmt[1];
             return $type_ignored_param($ign, $rest, $match);
+          // FALLTHROUGH
+          default:break;
           }
       }
       throw $caml_wrap_thrown_exception($Type_mismatch) as \Throwable;
@@ -4722,6 +4724,8 @@ final class CamlinternalFormat {
               return Vector{0, Vector{14, $sub_fmtty_rest__26}, $fmt__13};
             }
             break;
+          // FALLTHROUGH
+          default:break;
           }
       }
       throw $caml_wrap_thrown_exception($Type_mismatch) as \Throwable;
@@ -7325,6 +7329,8 @@ final class CamlinternalFormat {
                   $str_ind__5 = (int) ($str_ind__0 + 1) as dynamic;
                   $str_ind__0 = $str_ind__5;
                   $continue_label = "#";break;
+                // FALLTHROUGH
+                default:break;
                 }
               if ($continue_label === "#") {continue;}
             }
@@ -8335,6 +8341,8 @@ final class CamlinternalFormat {
                   return $parse_literal($minus__0, $aD_);
                 }
                 break;
+              // FALLTHROUGH
+              default:break;
               }
           }
         }
@@ -8833,6 +8841,8 @@ final class CamlinternalFormat {
                 $match__9 = $parse((int) ($str_ind + 1), $end_ind);
                 $fmt_rest__9 = $match__9[1];
                 return Vector{0, Vector{17, 5, $fmt_rest__9}};
+              // FALLTHROUGH
+              default:break;
               }
           }
         }
@@ -9271,6 +9281,8 @@ final class CamlinternalFormat {
             // FALLTHROUGH
             case 32:
               return 1;
+            // FALLTHROUGH
+            default:break;
             }
         }
         return 0;
@@ -9437,6 +9449,8 @@ final class CamlinternalFormat {
                     $symb,
                     $cst__36
                   );
+                // FALLTHROUGH
+                default:break;
                 }
               if ($continue_label === "#") {continue;}
             }

--- a/rehack_tests/output/stdlib.cma.php/Stdlib__bytes.php
+++ b/rehack_tests/output/stdlib.cma.php/Stdlib__bytes.php
@@ -406,6 +406,8 @@ final class Stdlib__bytes {
             case 1:
               $av_ = 2 as dynamic;
               break;
+            // FALLTHROUGH
+            default:break;
             }
           $n[1] = (int) ($n[1] + $av_);
           $aw_ = (int) ($i__0 + 1) as dynamic;
@@ -506,6 +508,8 @@ final class Stdlib__bytes {
             case 2:
               $caml_bytes_unsafe_set($s__0, $n[1], $c);
               break;
+            // FALLTHROUGH
+            default:break;
             }
           $n[1] += 1;
           $at_ = (int) ($i + 1) as dynamic;

--- a/rehack_tests/output/stdlib.cma.php/Stdlib__format.php
+++ b/rehack_tests/output/stdlib.cma.php/Stdlib__format.php
@@ -476,6 +476,8 @@ final class Stdlib__format {
                 return ((dynamic $cE_) : dynamic ==> {return 0;})($cB_);
               }
               return $ty;
+            // FALLTHROUGH
+            default:break;
             }
         }
         return 0;

--- a/rehack_tests/output/stdlib.cma.php/Stdlib__genlex.php
+++ b/rehack_tests/output/stdlib.cma.php/Stdlib__genlex.php
@@ -616,6 +616,8 @@ final class Stdlib__genlex {
                 case 6:
                   $call1($Stdlib_stream[12], $strm);
                   return 9;
+                // FALLTHROUGH
+                default:break;
                 }
             }
           }

--- a/rehack_tests/output/stdlib.cma.php/Stdlib__scanf.php
+++ b/rehack_tests/output/stdlib.cma.php/Stdlib__scanf.php
@@ -520,6 +520,8 @@ final class Stdlib__scanf {
           // FALLTHROUGH
           case 32:
             return 5;
+          // FALLTHROUGH
+          default:break;
           }
       }
       throw $caml_wrap_thrown_exception(Vector{0, $Assert_failure, $i_}) as \Throwable;
@@ -1195,6 +1197,8 @@ final class Stdlib__scanf {
             // FALLTHROUGH
             case 6:
               return 9;
+            // FALLTHROUGH
+            default:break;
             }
         }
       }
@@ -2390,6 +2394,8 @@ final class Stdlib__scanf {
                       $scan__2,
                       $token_string
                     );
+                  // FALLTHROUGH
+                  default:break;
                   }
               }
               $scan = (dynamic $width, dynamic $param, dynamic $ib) : dynamic ==> {

--- a/rehack_tests/output/stdlib.cma.php/Stdlib__stream.php
+++ b/rehack_tests/output/stdlib.cma.php/Stdlib__stream.php
@@ -143,6 +143,8 @@ final class Stdlib__stream {
               $r = $caml_bytes_unsafe_get($b[2], $b[4]);
               $b[4] = (int) ($b[4] + 1);
               return Vector{0, $r, $d__0};
+            // FALLTHROUGH
+            default:break;
             }
           if ($continue_label === "#") {continue;}
         }
@@ -248,6 +250,8 @@ final class Stdlib__stream {
               $s[1] = (int) ($s[1] + 1);
               $b[4] = (int) ($b[4] + 1);
               return 0;
+            // FALLTHROUGH
+            default:break;
             }
         }
         $match = $peek_data($s);


### PR DESCRIPTION
HHVM will throw exceptions at runtime if switch cases are unmatched.
There are a few instances of these emitted from js_of_ocaml. To address
to the possibilitiy of runtime exceptions, add dummy "default:break"
cases to the ends of all switch statements.